### PR TITLE
Update EigenDA proxy to match OP v1.7.6 client expectation

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -27,6 +27,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+      with:
+        submodules: true
 
     - name: Set up Go
       uses: actions/setup-go@v3
@@ -58,6 +60,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+      with:
+        submodules: true
 
     - name: Set up Go
       uses: actions/setup-go@v3

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ clean:
 test:
 	go test -v ./...
 
-e2e-test: submodules srs
+e2e-test: submodules
 	go test -timeout 50m -v ./test/e2e_test.go -testnet-integration
 
 .PHONY: lint

--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ An `EigenDACommitment` layer type has been added that supports verification agai
             |--------|--------|--------|--------|-----------------|
              commit   da layer  ext da   version  raw commitment
              type       type    type      byte
-
 ```
 
 The `raw commitment` for EigenDA is encoding certificate and kzg fields.

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/joho/godotenv"
 	"github.com/urfave/cli/v2"
 
+	"github.com/Layr-Labs/eigenda-proxy/server"
 	"github.com/ethereum-optimism/optimism/op-node/metrics"
 	opservice "github.com/ethereum-optimism/optimism/op-service"
 	"github.com/ethereum-optimism/optimism/op-service/cliapp"
@@ -22,7 +23,7 @@ func main() {
 	oplog.SetupDefaults()
 
 	app := cli.NewApp()
-	app.Flags = cliapp.ProtectFlags(Flags)
+	app.Flags = cliapp.ProtectFlags(server.Flags)
 	app.Version = opservice.FormatVersion(Version, "", "", "")
 	app.Name = "eigenda-proxy"
 	app.Usage = "EigenDA Proxy Sidecar Service"

--- a/eigenda/commitment.go
+++ b/eigenda/commitment.go
@@ -33,7 +33,7 @@ const (
 type Commitment []byte
 
 func (c Commitment) Encode() []byte {
-	return append([]byte{byte(op_plasma.GenericCommitmentType), byte(EigenDA), byte(EigenV0)}, c...)
+	return append([]byte{byte(EigenDA), byte(EigenV0)}, c...)
 }
 
 func StringToCommit(key string) (Commitment, error) {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/Layr-Labs/eigenda v0.7.2-0.20240606180508-e90cb7432ca5
 	github.com/consensys/gnark-crypto v0.12.1
-	github.com/ethereum-optimism/optimism v1.7.5-0.20240520224312-38cd9944494a
+	github.com/ethereum-optimism/optimism v1.7.6
 	github.com/ethereum/go-ethereum v1.14.0
 	github.com/joho/godotenv v1.5.1
 	github.com/prometheus/client_golang v1.19.0
@@ -49,7 +49,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deckarep/golang-set/v2 v2.1.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 // indirect
-	github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240516202831-8117b611dc3c // indirect
+	github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240522134500-19555bdbdc95 // indirect
 	github.com/ethereum/c-kzg-4844 v1.0.0 // indirect
 	github.com/fjl/memsize v0.0.2 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -142,10 +142,10 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/ethereum-optimism/op-geth v1.101315.1-rc.4 h1:8kKEkKIpEiDA1yJfrOO473Tyz4nGgSJHpyK1I0fbPDo=
 github.com/ethereum-optimism/op-geth v1.101315.1-rc.4/go.mod h1:TtEUbMSmnt2jrnmxAG0n7tj6ujmcBJ+TKkmU56+NMMw=
-github.com/ethereum-optimism/optimism v1.7.5-0.20240520224312-38cd9944494a h1:G/ZEyK8EGxte4pl/2Z5pP+/MbOFxsey4DzC6nHT/pqw=
-github.com/ethereum-optimism/optimism v1.7.5-0.20240520224312-38cd9944494a/go.mod h1:0SW2VbS19rHhno7VpBKODQzpUsb7xaNlBgdDkiu/O/I=
-github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240516202831-8117b611dc3c h1:dZYKUyjBsJfkCdlcqQ65pjIV1KD7P46ZvENKTxuxfJQ=
-github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240516202831-8117b611dc3c/go.mod h1:7xh2awFQqsiZxFrHKTgEd+InVfDRrkKVUIuK8SAFHp0=
+github.com/ethereum-optimism/optimism v1.7.6 h1:iwbO47lwa6vi5gQA0Lbnf/uOzmqXFHvXgmziLtVMbwM=
+github.com/ethereum-optimism/optimism v1.7.6/go.mod h1:0zhgYDWSk2ZgzFkhA4ENcWRvS0EuO9IUQAhXenvtSZM=
+github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240522134500-19555bdbdc95 h1:GjXKQg6u6WkEIcY0dvW2IKhMRY8cVjwdw+rNKhduAo8=
+github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240522134500-19555bdbdc95/go.mod h1:7xh2awFQqsiZxFrHKTgEd+InVfDRrkKVUIuK8SAFHp0=
 github.com/ethereum/c-kzg-4844 v1.0.0 h1:0X1LBXxaEtYD9xsyj9B9ctQEZIpnvVDeoBx8aHEwTNA=
 github.com/ethereum/c-kzg-4844 v1.0.0/go.mod h1:VewdlzQmpT5QSrVhbBuGoCdFJkpaJlO1aQputP83wc0=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=

--- a/server/flags.go
+++ b/server/flags.go
@@ -1,4 +1,4 @@
-package main
+package server
 
 import (
 	"fmt"

--- a/server/load_store.go
+++ b/server/load_store.go
@@ -1,0 +1,41 @@
+package server
+
+import (
+	"context"
+
+	"github.com/Layr-Labs/eigenda-proxy/store"
+	"github.com/Layr-Labs/eigenda-proxy/verify"
+	"github.com/Layr-Labs/eigenda/api/clients"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+func LoadStore(cfg CLIConfig, ctx context.Context, log log.Logger) (store.Store, error) {
+	log.Info("Using eigenda backend")
+	daCfg := cfg.EigenDAConfig
+
+	verifier, err := verify.NewVerifier(daCfg.KzgConfig())
+	if err != nil {
+		return nil, err
+	}
+
+	maxBlobLength, err := daCfg.GetMaxBlobLength()
+	if err != nil {
+		return nil, err
+	}
+
+	if cfg.MemStoreCfg.Enabled {
+		log.Info("Using memstore backend")
+		return store.NewMemStore(ctx, &cfg.MemStoreCfg, verifier, log, maxBlobLength)
+	}
+
+	client, err := clients.NewEigenDAClient(log, daCfg.ClientConfig)
+	if err != nil {
+		return nil, err
+	}
+	return store.NewEigenDAStore(
+		ctx,
+		client,
+		verifier,
+		maxBlobLength,
+	)
+}

--- a/store/eigenda.go
+++ b/store/eigenda.go
@@ -31,8 +31,8 @@ func NewEigenDAStore(ctx context.Context, client *clients.EigenDAClient, v *veri
 // Get fetches a blob from DA using certificate fields and verifies blob
 // against commitment to ensure data is valid and non-tampered.
 func (e EigenDAStore) Get(ctx context.Context, key []byte, domain common.DomainType) ([]byte, error) {
-	var cert *disperser.BlobInfo
-	err := rlp.DecodeBytes(key, cert)
+	var cert disperser.BlobInfo
+	err := rlp.DecodeBytes(key, &cert)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode DA cert to RLP format: %w", err)
 	}

--- a/store/memory.go
+++ b/store/memory.go
@@ -23,7 +23,7 @@ const (
 	MemStoreFlagName   = "memstore.enabled"
 	ExpirationFlagName = "memstore.expiration"
 
-	DefaultPruneInterval = 1 * time.Minute
+	DefaultPruneInterval = 500 * time.Millisecond
 )
 
 type MemStoreConfig struct {

--- a/store/memory.go
+++ b/store/memory.go
@@ -23,7 +23,7 @@ const (
 	MemStoreFlagName   = "memstore.enabled"
 	ExpirationFlagName = "memstore.expiration"
 
-	DefaultPruneInterval = 500 * time.Millisecond
+	DefaultPruneInterval = 1 * time.Minute
 )
 
 type MemStoreConfig struct {

--- a/store/memory.go
+++ b/store/memory.go
@@ -104,7 +104,7 @@ func (e *MemStore) Get(ctx context.Context, commit []byte, domain eigendacommon.
 	e.RLock()
 	defer e.RUnlock()
 
-	var cert *disperser.BlobInfo
+	var cert disperser.BlobInfo
 	err := rlp.DecodeBytes(commit, &cert)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode DA cert to RLP format: %w", err)

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -139,6 +139,10 @@ func TestE2EPutGetLogicForEigenDAStore(t *testing.T) {
 }
 
 func TestE2EPutGetLogicForMemoryStore(t *testing.T) {
+	if runTestnetIntegrationTests {
+		t.Skip("Skipping non-testnet integration test")
+	}
+
 	ts, kill := createTestSuite(t, true)
 	defer kill()
 

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -5,22 +5,20 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"runtime"
 	"testing"
 	"time"
 
-	proxy "github.com/Layr-Labs/eigenda-proxy"
 	"github.com/Layr-Labs/eigenda-proxy/eigenda"
 	"github.com/Layr-Labs/eigenda-proxy/metrics"
+	"github.com/Layr-Labs/eigenda-proxy/server"
 	"github.com/Layr-Labs/eigenda-proxy/store"
-	"github.com/Layr-Labs/eigenda-proxy/verify"
 	"github.com/Layr-Labs/eigenda/api/clients"
-	"github.com/Layr-Labs/eigenda/encoding/kzg"
 	op_plasma "github.com/ethereum-optimism/optimism/op-plasma"
+	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
 
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var runTestnetIntegrationTests bool
@@ -42,15 +40,15 @@ const (
 type TestSuite struct {
 	ctx    context.Context
 	log    log.Logger
-	server *proxy.Server
+	server *server.Server
 }
 
-func createTestSuite(t *testing.T) (TestSuite, func()) {
+func createTestSuite(t *testing.T, useMemory bool) (TestSuite, func()) {
 	ctx := context.Background()
 
 	// load signer key from environment
 	pk := os.Getenv(privateKey)
-	if pk == "" {
+	if pk == "" && !useMemory {
 		t.Fatal("SIGNER_PRIVATE_KEY environment variable not set")
 	}
 
@@ -62,7 +60,7 @@ func createTestSuite(t *testing.T) (TestSuite, func()) {
 
 	oplog.SetGlobalLogHandler(log.Handler())
 
-	testCfg := eigenda.Config{
+	eigendaCfg := eigenda.Config{
 		ClientConfig: clients.EigenDAClientConfig{
 			RPC:                      holeskyDA,
 			StatusQueryTimeout:       time.Minute * 45,
@@ -70,42 +68,34 @@ func createTestSuite(t *testing.T) (TestSuite, func()) {
 			DisableTLS:               false,
 			SignerPrivateKeyHex:      pk,
 		},
+		CacheDir:               "../operator-setup/resources/SRSTables",
+		G1Path:                 "../operator-setup/resources/g1_abbr.point",
+		G2Path:                 "../test/resources/g2.point", // do we need this?
+		MaxBlobLength:          "90kib",
+		G2PowerOfTauPath:       "../operator-setup/resources/g2_abbr.point.powerOf2",
+		PutBlobEncodingVersion: 0x00,
 	}
 
-	// these values can be generated locally by running `make srs`
-	kzgCfg := &kzg.KzgConfig{
-		G1Path:          "../operator-setup/resources/g1.point",
-		G2PowerOf2Path:  "../operator-setup/resources/g2.point.powerOf2",
-		CacheDir:        "../operator-setup/resources/SRSTables",
-		G2Path:          "../test/resources/g2.point",
-		SRSOrder:        3000,
-		SRSNumberToLoad: 3000,
-		NumWorker:       uint64(runtime.GOMAXPROCS(0)),
+	memstoreCfg := store.MemStoreConfig{
+		Enabled:        useMemory,
+		BlobExpiration: 14 * 24 * time.Hour,
 	}
 
-	client, err := clients.NewEigenDAClient(log, testCfg.ClientConfig)
-	if err != nil {
-		panic(err)
-	}
+	store, err := server.LoadStore(
+		server.CLIConfig{
+			EigenDAConfig: eigendaCfg,
+			MemStoreCfg:   memstoreCfg,
+			MetricsCfg:    opmetrics.CLIConfig{},
+		},
+		ctx,
+		log,
+	)
+	require.NoError(t, err)
+	server := server.NewServer(host, port, store, log, metrics.NoopMetrics)
 
-	verifier, err := verify.NewVerifier(kzgCfg)
-	if err != nil {
-		panic(err)
-	}
-
-	daStore, err := store.NewEigenDAStore(ctx, client, verifier, 1024*1024*2)
-	if err != nil {
-		panic(err)
-	}
-
-	server := proxy.NewServer(host, port, daStore, log, metrics.NoopMetrics)
-
-	go func() {
-		t.Log("Starting proxy server on separate routine...")
-		if err := server.Start(); err != nil {
-			panic(err)
-		}
-	}()
+	t.Log("Starting proxy server...")
+	err = server.Start()
+	require.NoError(t, err)
 
 	kill := func() {
 		if err := server.Stop(); err != nil {
@@ -125,7 +115,7 @@ func TestE2EPutGetLogicForEigenDAStore(t *testing.T) {
 		t.Skip("Skipping testnet integration test")
 	}
 
-	ts, kill := createTestSuite(t)
+	ts, kill := createTestSuite(t, false)
 	defer kill()
 
 	daClient := op_plasma.NewDAClient(fmt.Sprintf("%s://%s:%d", transport, host, port), false, false)
@@ -139,12 +129,35 @@ func TestE2EPutGetLogicForEigenDAStore(t *testing.T) {
 
 	t.Log("Setting input data on proxy server...")
 	commit, err := daClient.SetInput(ts.ctx, testPreimage)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// 2 - fetch data from EigenDA for generated commitment key
 	t.Log("Getting input data from proxy server...")
 	preimage, err := daClient.GetInput(ts.ctx, commit)
-	assert.NoError(t, err)
-	assert.Equal(t, testPreimage, preimage)
+	require.NoError(t, err)
+	require.Equal(t, testPreimage, preimage)
+}
 
+func TestE2EPutGetLogicForMemoryStore(t *testing.T) {
+	ts, kill := createTestSuite(t, true)
+	defer kill()
+
+	daClient := op_plasma.NewDAClient(fmt.Sprintf("%s://%s:%d", transport, host, port), false, false)
+	t.Log("Waiting for client to establish connection with plasma server...")
+	// wait for server to come online after starting
+	time.Sleep(5 * time.Second)
+
+	// 1 - write arbitrary data to EigenDA
+
+	var testPreimage = []byte("inter-subjective and not objective!")
+
+	t.Log("Setting input data on proxy server...")
+	commit, err := daClient.SetInput(ts.ctx, testPreimage)
+	require.NoError(t, err)
+
+	// 2 - fetch data from EigenDA for generated commitment key
+	t.Log("Getting input data from proxy server...")
+	preimage, err := daClient.GetInput(ts.ctx, commit)
+	require.NoError(t, err)
+	require.Equal(t, testPreimage, preimage)
 }


### PR DESCRIPTION
* moves LoadServer() and server.go into a new server package so that LoadServer() can be used in e2e_test.go (avoiding duplication of DI efforts)
* Removes GenericCommitmentByte from the returned commitment, since it is prepended by the OP client on the clients side..?
* Enable WithLogging() middleware
* Expand WithLogging() to support error logging, update handler signatures and implementations to tie into this
* Update path patterns to match the usage by the OP plasma client