### PR TITLE
Docs rectify typographical inaccuracies

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -42,7 +42,7 @@ func New(cfg *Config) ProxyClient {
 	}
 }
 
-// Health indicates if server is operational; useful for event based awaits
+// Health indicates if the server is operational; useful for event based awaits
 // when integration testing
 func (c *client) Health() error {
 	url := c.cfg.URL + "/health"

--- a/common/common.go
+++ b/common/common.go
@@ -14,7 +14,7 @@ var (
 
 type Certificate = disperser.BlobInfo
 
-// DomainType is a enumeration type for the different data domains for which a
+// DomainType is an enumeration type for the different data domains for which a
 // blob can exist between
 type DomainType uint8
 

--- a/e2e/server_test.go
+++ b/e2e/server_test.go
@@ -31,7 +31,7 @@ func TestPlasmaClient(t *testing.T) {
 
 	daClient := op_plasma.NewDAClient(ts.Address(), false, false)
 	t.Log("Waiting for client to establish connection with plasma server...")
-	// wait for server to come online after starting
+	// wait for the server to come online after starting
 	time.Sleep(5 * time.Second)
 
 	// 1 - write arbitrary data to EigenDA

--- a/store/eigenda.go
+++ b/store/eigenda.go
@@ -88,7 +88,7 @@ func (e EigenDAStore) Put(ctx context.Context, value []byte) (comm []byte, err e
 	return bytes, nil
 }
 
-// Entries is a no-op for EigenDA Store
+// Entries are a no-op for EigenDA Store
 func (e EigenDAStore) Stats() *common.Stats {
 	return nil
 }


### PR DESCRIPTION
his PR addresses several typographical errors across various files in the project. The changes improve readability and maintain the professional standard of the documentation and code comments.

Justification
Typographical errors, while minor, can detract from the overall quality of the project. Correcting these errors ensures clarity and professionalism, making the project more accessible and understandable for current and future contributors.

Hope it helps.