### PR TITLE
Fix syntax in op-devnet-allocs.sh

### DIFF
--- a/scripts/op-devnet-allocs.sh
+++ b/scripts/op-devnet-allocs.sh
@@ -29,3 +29,4 @@ if [ $? -eq 0 ] ; then
 else
     echo "Failed to clean up ${REPO_NAME} repo"
     exit ${STATUS}
+fi


### PR DESCRIPTION
The ending "fi" for the if-statement was accidentally omitted.