### PR TITLE
Update lint.yml

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,10 +20,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.54
-          args: --timeout 3m --verbose
+          version: v1.60
+          args: --timeout 3m
 
   go-sec:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Pull Request Template

<!-- If your PR fixes an open issue, use `Closes #NNN` to link your PR with the
issue, replacing `#NNN` with the issue number you are fixing -->

## Fixes Issue

<!-- Example: Closes #NNN -->
Fixes #

## Changes proposed

<!-- List all the proposed changes in your PR -->
<!-- Add the screenshots of the changes below if applicable -->

update golangci-lint github action to v6.
v3 uses a deprecated --out-format which was removed in v6.
See this run https://github.com/Layr-Labs/eigenda-proxy/actions/runs/10498975752/job/29084898659?pr=94 which is completely useless and doesn't show the actual error
<img width="841" alt="image" src="https://github.com/user-attachments/assets/e4fdb6da-fab6-47ad-8a0f-3279b59287b7">

Also removing the --verbose flag because it just adds a bunch of clutter which is not useful I find.
Compare:
<img width="1419" alt="image" src="https://github.com/user-attachments/assets/8f02112d-8985-47af-bce5-c1aa86bcc62a">


### Screenshots (Optional)

## Note to reviewers

<!-- Add notes to reviewers if applicable -->