### PR TITLE
Feat memstore artificial latency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,8 @@ stop-minio:
 		docker stop minio && docker rm minio; \
 	fi
 
-run-server:
-	./bin/eigenda-proxy
+run-memstore-server:
+	./bin/eigenda-proxy --memstore.enabled
 
 clean:
 	rm bin/eigenda-proxy

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ In order to disperse to the EigenDA network in production, or at high throughput
 | `--log.pid` | `false` | `$EIGENDA_PROXY_LOG_PID` | Show pid in the log. |
 | `--memstore.enabled` | `false` | `$MEMSTORE_ENABLED` | Whether to use mem-store for DA logic. |
 | `--memstore.expiration` | `25m0s` | `$MEMSTORE_EXPIRATION` | Duration that a mem-store blob/commitment pair are allowed to live. |
+| `--memstore.put-latency` | `0` | `$MEMSTORE_PUT_LATENCY` | Artificial latency added for memstore backend to mimic EigenDA's dispersal latency. |
+| `--memstore.get-latency` | `0` | `$MEMSTORE_GET_LATENCY` | Artificial latency added for memstore backend to mimic EigenDA's retrieval latency. |
 | `--metrics.addr` | `"0.0.0.0"` | `$EIGENDA_PROXY_METRICS_ADDR` | Metrics listening address. |
 | `--metrics.enabled` | `false` | `$EIGENDA_PROXY_METRICS_ENABLED` | Enable the metrics server. |
 | `--metrics.port` | `7300` | `$EIGENDA_PROXY_METRICS_PORT` | Metrics listening port. |

--- a/cmd/server/entrypoint.go
+++ b/cmd/server/entrypoint.go
@@ -13,9 +13,6 @@ import (
 )
 
 func StartProxySvr(cliCtx *cli.Context) error {
-	if err := server.CheckRequired(cliCtx); err != nil {
-		return err
-	}
 	cfg := server.ReadCLIConfig(cliCtx)
 	if err := cfg.Check(); err != nil {
 		return err

--- a/server/config.go
+++ b/server/config.go
@@ -38,6 +38,8 @@ const (
 	// memstore flags
 	MemstoreFlagName           = "memstore.enabled"
 	MemstoreExpirationFlagName = "memstore.expiration"
+	MemstorePutLatencyFlagName = "memstore.put-latency"
+	MemstoreGetLatencyFlagName = "memstore.get-latency"
 
 	// S3 client flags
 	S3CredentialTypeFlagName  = "s3.credential-type" // #nosec G101
@@ -90,6 +92,8 @@ type Config struct {
 	// Memstore
 	MemstoreEnabled        bool
 	MemstoreBlobExpiration time.Duration
+	MemstoreGetLatency     time.Duration
+	MemstorePutLatency     time.Duration
 
 	// routing
 	FallbackTargets []string
@@ -179,6 +183,8 @@ func ReadConfig(ctx *cli.Context) Config {
 		EthConfirmationDepth:   ctx.Int64(EthConfirmationDepthFlagName),
 		MemstoreEnabled:        ctx.Bool(MemstoreFlagName),
 		MemstoreBlobExpiration: ctx.Duration(MemstoreExpirationFlagName),
+		MemstoreGetLatency:     ctx.Duration(MemstoreGetLatencyFlagName),
+		MemstorePutLatency:     ctx.Duration(MemstorePutLatencyFlagName),
 		FallbackTargets:        ctx.StringSlice(FallbackTargets),
 		CacheTargets:           ctx.StringSlice(CacheTargets),
 	}
@@ -418,6 +424,18 @@ func CLIFlags() []cli.Flag {
 			Usage:   "Duration that a mem-store blob/commitment pair are allowed to live.",
 			Value:   25 * time.Minute,
 			EnvVars: []string{"MEMSTORE_EXPIRATION"},
+		},
+		&cli.DurationFlag{
+			Name:    MemstorePutLatencyFlagName,
+			Usage:   "Artificial latency added for memstore backend to mimic EigenDA's dispersal latency.",
+			Value:   0,
+			EnvVars: []string{"MEMSTORE_PUT_LATENCY"},
+		},
+		&cli.DurationFlag{
+			Name:    MemstoreGetLatencyFlagName,
+			Usage:   "Artificial latency added for memstore backend to mimic EigenDA's retrieval latency.",
+			Value:   0,
+			EnvVars: []string{"MEMSTORE_GET_LATENCY"},
 		},
 		&cli.StringSliceFlag{
 			Name:    FallbackTargets,

--- a/server/flags.go
+++ b/server/flags.go
@@ -1,8 +1,6 @@
 package server
 
 import (
-	"fmt"
-
 	"github.com/Layr-Labs/eigenda-proxy/store"
 	"github.com/urfave/cli/v2"
 
@@ -26,7 +24,7 @@ var (
 	ListenAddrFlag = &cli.StringFlag{
 		Name:    ListenAddrFlagName,
 		Usage:   "server listening address",
-		Value:   "127.0.0.1",
+		Value:   "0.0.0.0",
 		EnvVars: prefixEnvVars("ADDR"),
 	}
 	PortFlag = &cli.IntFlag{
@@ -37,12 +35,12 @@ var (
 	}
 )
 
-var requiredFlags = []cli.Flag{
+var requiredFlags = []cli.Flag{}
+
+var optionalFlags = []cli.Flag{
 	ListenAddrFlag,
 	PortFlag,
 }
-
-var optionalFlags = []cli.Flag{}
 
 func init() {
 	optionalFlags = append(optionalFlags, oplog.CLIFlags(EnvVarPrefix)...)
@@ -73,15 +71,6 @@ func (c CLIConfig) Check() error {
 	err := c.EigenDAConfig.Check()
 	if err != nil {
 		return err
-	}
-	return nil
-}
-
-func CheckRequired(ctx *cli.Context) error {
-	for _, f := range requiredFlags {
-		if !ctx.IsSet(f.Names()[0]) {
-			return fmt.Errorf("flag %s is required", f.Names()[0])
-		}
 	}
 	return nil
 }

--- a/server/flags.go
+++ b/server/flags.go
@@ -20,37 +20,27 @@ func prefixEnvVars(name string) []string {
 	return opservice.PrefixEnvVar(EnvVarPrefix, name)
 }
 
-var (
-	ListenAddrFlag = &cli.StringFlag{
+// Flags contains the list of configuration options available to the binary.
+var Flags = []cli.Flag{
+	&cli.StringFlag{
 		Name:    ListenAddrFlagName,
 		Usage:   "server listening address",
 		Value:   "0.0.0.0",
 		EnvVars: prefixEnvVars("ADDR"),
-	}
-	PortFlag = &cli.IntFlag{
+	},
+	&cli.IntFlag{
 		Name:    PortFlagName,
 		Usage:   "server listening port",
 		Value:   3100,
 		EnvVars: prefixEnvVars("PORT"),
-	}
-)
-
-var requiredFlags = []cli.Flag{}
-
-var optionalFlags = []cli.Flag{
-	ListenAddrFlag,
-	PortFlag,
+	},
 }
 
 func init() {
-	optionalFlags = append(optionalFlags, oplog.CLIFlags(EnvVarPrefix)...)
-	optionalFlags = append(optionalFlags, CLIFlags()...)
-	optionalFlags = append(optionalFlags, opmetrics.CLIFlags(EnvVarPrefix)...)
-	Flags = append(requiredFlags, optionalFlags...) //nolint:gocritic // this is a global variable
+	Flags = append(Flags, oplog.CLIFlags(EnvVarPrefix)...)
+	Flags = append(Flags, CLIFlags()...)
+	Flags = append(Flags, opmetrics.CLIFlags(EnvVarPrefix)...)
 }
-
-// Flags contains the list of configuration options available to the binary.
-var Flags []cli.Flag
 
 type CLIConfig struct {
 	S3Config      store.S3Config

--- a/server/load_store.go
+++ b/server/load_store.go
@@ -47,7 +47,7 @@ func LoadStoreRouter(ctx context.Context, cfg CLIConfig, log log.Logger) (store.
 	var eigenda store.KeyGeneratedStore
 	if cfg.EigenDAConfig.MemstoreEnabled {
 		log.Info("Using mem-store backend for EigenDA")
-		eigenda, err = store.NewMemStore(ctx, verifier, log, maxBlobLength, cfg.EigenDAConfig.MemstoreBlobExpiration)
+		eigenda, err = store.NewMemStore(ctx, verifier, log, maxBlobLength, cfg.EigenDAConfig.MemstoreBlobExpiration, cfg.EigenDAConfig.MemstorePutLatency, cfg.EigenDAConfig.MemstoreGetLatency)
 	} else {
 		var client *clients.EigenDAClient
 		log.Info("Using EigenDA backend")

--- a/server/load_store.go
+++ b/server/load_store.go
@@ -47,7 +47,12 @@ func LoadStoreRouter(ctx context.Context, cfg CLIConfig, log log.Logger) (store.
 	var eigenda store.KeyGeneratedStore
 	if cfg.EigenDAConfig.MemstoreEnabled {
 		log.Info("Using mem-store backend for EigenDA")
-		eigenda, err = store.NewMemStore(ctx, verifier, log, maxBlobLength, cfg.EigenDAConfig.MemstoreBlobExpiration, cfg.EigenDAConfig.MemstorePutLatency, cfg.EigenDAConfig.MemstoreGetLatency)
+		eigenda, err = store.NewMemStore(ctx, verifier, log, store.MemStoreConfig{
+			MaxBlobSizeBytes: maxBlobLength,
+			BlobExpiration:   cfg.EigenDAConfig.MemstoreBlobExpiration,
+			PutLatency:       cfg.EigenDAConfig.MemstorePutLatency,
+			GetLatency:       cfg.EigenDAConfig.MemstoreGetLatency,
+		})
 	} else {
 		var client *clients.EigenDAClient
 		log.Info("Using EigenDA backend")

--- a/store/memory.go
+++ b/store/memory.go
@@ -30,10 +30,6 @@ type MemStoreConfig struct {
 	GetLatency time.Duration
 }
 
-var memStoreConfigDefaults = MemStoreConfig{
-	MaxBlobSizeBytes: 1024 * 1024,
-}
-
 /*
 MemStore is a simple in-memory store for blobs which uses an expiration
 time to evict blobs to best emulate the ephemeral nature of blobs dispersed to

--- a/store/memory_test.go
+++ b/store/memory_test.go
@@ -16,6 +16,15 @@ const (
 	testPreimage = "Four score and seven years ago"
 )
 
+func getDefaultTestConfig() MemStoreConfig {
+	return MemStoreConfig{
+		MaxBlobSizeBytes: 1024 * 1024,
+		BlobExpiration:   time.Hour * 1000,
+		PutLatency:       0,
+		GetLatency:       0,
+	}
+}
+
 func TestGetSet(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -41,9 +50,7 @@ func TestGetSet(t *testing.T) {
 		ctx,
 		verifier,
 		log.New(),
-		1024*1024*2,
-		time.Hour*1000,
-		0, 0,
+		getDefaultTestConfig(),
 	)
 
 	require.NoError(t, err)
@@ -84,9 +91,7 @@ func TestExpiration(t *testing.T) {
 		ctx,
 		verifier,
 		log.New(),
-		1024*1024*2,
-		time.Millisecond*10,
-		0, 0,
+		getDefaultTestConfig(),
 	)
 
 	require.NoError(t, err)
@@ -133,9 +138,7 @@ func TestLatency(t *testing.T) {
 		ctx,
 		verifier,
 		log.New(),
-		1024*1024*2,
-		time.Millisecond*10,
-		putLatency, getLatency,
+		getDefaultTestConfig(),
 	)
 
 	require.NoError(t, err)

--- a/store/memory_test.go
+++ b/store/memory_test.go
@@ -16,7 +16,7 @@ const (
 	testPreimage = "Four score and seven years ago"
 )
 
-func getDefaultTestConfig() MemStoreConfig {
+func getDefaultMemStoreTestConfig() MemStoreConfig {
 	return MemStoreConfig{
 		MaxBlobSizeBytes: 1024 * 1024,
 		BlobExpiration:   0,
@@ -25,32 +25,32 @@ func getDefaultTestConfig() MemStoreConfig {
 	}
 }
 
+func getDefaultVerifierTestConfig() *verify.Config {
+	return &verify.Config{
+		Verify: false,
+		KzgConfig: &kzg.KzgConfig{
+			G1Path:          "../resources/g1.point",
+			G2PowerOf2Path:  "../resources/g2.point.powerOf2",
+			CacheDir:        "../resources/SRSTables",
+			SRSOrder:        3000,
+			SRSNumberToLoad: 3000,
+			NumWorker:       uint64(runtime.GOMAXPROCS(0)),
+		},
+	}
+}
+
 func TestGetSet(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	kzgConfig := &kzg.KzgConfig{
-		G1Path:          "../resources/g1.point",
-		G2PowerOf2Path:  "../resources/g2.point.powerOf2",
-		CacheDir:        "../resources/SRSTables",
-		SRSOrder:        3000,
-		SRSNumberToLoad: 3000,
-		NumWorker:       uint64(runtime.GOMAXPROCS(0)),
-	}
-
-	cfg := &verify.Config{
-		Verify:    false,
-		KzgConfig: kzgConfig,
-	}
-
-	verifier, err := verify.NewVerifier(cfg, nil)
+	verifier, err := verify.NewVerifier(getDefaultVerifierTestConfig(), nil)
 	require.NoError(t, err)
 
 	ms, err := NewMemStore(
 		ctx,
 		verifier,
 		log.New(),
-		getDefaultTestConfig(),
+		getDefaultMemStoreTestConfig(),
 	)
 
 	require.NoError(t, err)
@@ -70,24 +70,10 @@ func TestExpiration(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	kzgConfig := &kzg.KzgConfig{
-		G1Path:          "../resources/g1.point",
-		G2PowerOf2Path:  "../resources/g2.point.powerOf2",
-		CacheDir:        "../resources/SRSTables",
-		SRSOrder:        3000,
-		SRSNumberToLoad: 3000,
-		NumWorker:       uint64(runtime.GOMAXPROCS(0)),
-	}
-
-	cfg := &verify.Config{
-		Verify:    false,
-		KzgConfig: kzgConfig,
-	}
-
-	verifier, err := verify.NewVerifier(cfg, nil)
+	verifier, err := verify.NewVerifier(getDefaultVerifierTestConfig(), nil)
 	require.NoError(t, err)
 
-	memstoreConfig := getDefaultTestConfig()
+	memstoreConfig := getDefaultMemStoreTestConfig()
 	memstoreConfig.BlobExpiration = 10 * time.Millisecond
 	ms, err := NewMemStore(
 		ctx,
@@ -119,24 +105,10 @@ func TestLatency(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	kzgConfig := &kzg.KzgConfig{
-		G1Path:          "../resources/g1.point",
-		G2PowerOf2Path:  "../resources/g2.point.powerOf2",
-		CacheDir:        "../resources/SRSTables",
-		SRSOrder:        3000,
-		SRSNumberToLoad: 3000,
-		NumWorker:       uint64(runtime.GOMAXPROCS(0)),
-	}
-
-	cfg := &verify.Config{
-		Verify:    false,
-		KzgConfig: kzgConfig,
-	}
-
-	verifier, err := verify.NewVerifier(cfg, nil)
+	verifier, err := verify.NewVerifier(getDefaultVerifierTestConfig(), nil)
 	require.NoError(t, err)
 
-	config := getDefaultTestConfig()
+	config := getDefaultMemStoreTestConfig()
 	config.PutLatency = putLatency
 	config.GetLatency = getLatency
 	ms, err := NewMemStore(ctx, verifier, log.New(), config)


### PR DESCRIPTION
Closes #86 

We want to test our op-batcher parallel blob submission with memstore backend. To test it, we need blob to actually take some time to disperse, so added option to add artificial latency to put/get requests.