### PR TITLE
Update Makefile: add disperse-test-blob

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,9 @@ stop-minio:
 run-memstore-server:
 	./bin/eigenda-proxy --memstore.enabled
 
+disperse-test-blob:
+	curl -X POST -d my-blob-content http://127.0.0.1:3100/put/ --output stdout
+
 clean:
 	rm bin/eigenda-proxy
 

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ run-memstore-server:
 	./bin/eigenda-proxy --memstore.enabled
 
 disperse-test-blob:
-	curl -X POST -d my-blob-content http://127.0.0.1:3100/put/ --output stdout
+	curl -X POST -d my-blob-content http://127.0.0.1:3100/put/
 
 clean:
 	rm bin/eigenda-proxy


### PR DESCRIPTION
This'll make it easier to test that the da-proxy is working manually. eg:
```
make run-memstore-server
make disperse-test-blob
```
