### PR TITLE
BREAKING suggestion: change dockerfile to use entrypoint instead of cmd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,4 @@ COPY --from=builder /app/resources/ /app/resources/
 EXPOSE 4242 7300
 
 # Run app
-CMD ["./eigenda-proxy"]
+ENTRYPOINT ["./eigenda-proxy"]


### PR DESCRIPTION
I personally prefer my dockerfiles that are meant to run a single binary to have that binary as the entrypoint. This way I just have to pass the flags directly and don't need to know how the binary was named inside the image.

Compare with this change
```
docker run eigenda-proxy:latest --memstore.enabled
```

to what we currently have
```
docker run eigenda-proxy:latest ./eigenda-proxy --memstore.enabled
```
This is wordy for no reason, but also I need to inspect Dockerfile manually to check where the binary is located.

This is a breaking change however, given that RaaS's or whoever has this setup in a docker-compose file somewhere will need to change their CMD to work with this (just remove the name of the binary)