### PR TITLE
Chore give docker image fullname

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY go.mod go.sum ./
 # Download all dependencies. Dependencies will be cached if the go.mod and go.sum files are not changed
 RUN go mod download
 
-# Copy the rest of the application code
+# Copy the rest of the application code (filtered by .dockerignore)
 COPY . .
 
 # Build the application binary

--- a/Dockerfile.dockerignore
+++ b/Dockerfile.dockerignore
@@ -1,2 +1,9 @@
-!/go.mod
-!/go.sum
+# Ignore everything
+*
+
+# Re-include necessary files only
+!go.mod
+!go.sum
+!*/**/*.go
+!Makefile
+!resources

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-APP_NAME = eigenda-proxy
+IMAGE_NAME = ghcr.io/layr-labs/eigenda-proxy
 LINTER_VERSION = v1.52.1
 LINTER_URL = https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh
 GET_LINT_CMD = "curl -sSfL $(LINTER_URL) | sh -s -- -b $(go env GOPATH)/bin $(LINTER_VERSION)"
@@ -21,7 +21,7 @@ eigenda-proxy:
 
 .PHONY: docker-build
 docker-build:
-	@docker build -t $(APP_NAME) .
+	@docker build -t $(IMAGE_NAME) .
 
 run-minio:
 	docker run -p 4566:9000 -d -e "MINIO_ROOT_USER=minioadmin" -e "MINIO_ROOT_PASSWORD=minioadmin" --name minio minio/minio server /data


### PR DESCRIPTION
Cleanup dockerignore file to only copy into build the files that we need. More chance of hitting cache this way

Also renamed app_name in Makefile to use the full ghcr image name that we use. This way I can build locally with latest tag and use that in my op devnet compose file. Otherwise it was building an image with docker.io prefix (going to dockerhub).