### PR TITLE
chore(breaking): add EIGENDA_PROXY prefix to memstore flags

### DIFF
--- a/.env.example.holesky
+++ b/.env.example.holesky
@@ -62,10 +62,10 @@ EIGENDA_PROXY_SERVICE_MANAGER_ADDR=0xD4A7E1Bd8015057293f0D0A557088c286942e84b
 # EIGENDA_PROXY_LOG_PID=false
 
 # Whether to use mem-store for DA logic
-# MEMSTORE_ENABLED=false
+# EIGENDA_PROXY_MEMSTORE_ENABLED=false
 
 # Duration that a blob/commitment pair are allowed to live
-# MEMSTORE_EXPIRATION=25m0s
+# EIGENDA_PROXY_MEMSTORE_EXPIRATION=25m0s
 
 # Metrics listening address
 # EIGENDA_PROXY_METRICS_ADDR=0.0.0.0

--- a/.env.example.mainnet
+++ b/.env.example.mainnet
@@ -61,10 +61,10 @@ EIGENDA_PROXY_SERVICE_MANAGER_ADDR=0x870679E138bCdf293b7Ff14dD44b70FC97e12fc0
 # EIGENDA_PROXY_LOG_PID=false
 
 # Whether to use mem-store for DA logic
-# MEMSTORE_ENABLED=false
+# EIGENDA_PROXY_MEMSTORE_ENABLED=false
 
 # Duration that a blob/commitment pair are allowed to live
-# MEMSTORE_EXPIRATION=25m0s
+# EIGENDA_PROXY_MEMSTORE_EXPIRATION=25m0s
 
 # Metrics listening address
 # EIGENDA_PROXY_METRICS_ADDR=0.0.0.0

--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ In order to disperse to the EigenDA network in production, or at high throughput
 | `--log.format` | `text` | `$EIGENDA_PROXY_LOG_FORMAT` | Format the log output. Supported formats: 'text', 'terminal', 'logfmt', 'json', 'json-pretty'. |
 | `--log.level` | `INFO` | `$EIGENDA_PROXY_LOG_LEVEL` | The lowest log level that will be output. |
 | `--log.pid` | `false` | `$EIGENDA_PROXY_LOG_PID` | Show pid in the log. |
-| `--memstore.enabled` | `false` | `$MEMSTORE_ENABLED` | Whether to use mem-store for DA logic. |
-| `--memstore.expiration` | `25m0s` | `$MEMSTORE_EXPIRATION` | Duration that a mem-store blob/commitment pair are allowed to live. |
-| `--memstore.put-latency` | `0` | `$MEMSTORE_PUT_LATENCY` | Artificial latency added for memstore backend to mimic EigenDA's dispersal latency. |
-| `--memstore.get-latency` | `0` | `$MEMSTORE_GET_LATENCY` | Artificial latency added for memstore backend to mimic EigenDA's retrieval latency. |
+| `--memstore.enabled` | `false` | `$EIGENDA_PROXY_MEMSTORE_ENABLED` | Whether to use mem-store for DA logic. |
+| `--memstore.expiration` | `25m0s` | `$EIGENDA_PROXY_MEMSTORE_EXPIRATION` | Duration that a mem-store blob/commitment pair are allowed to live. |
+| `--memstore.put-latency` | `0` | `$EIGENDA_PROXY_MEMSTORE_PUT_LATENCY` | Artificial latency added for memstore backend to mimic EigenDA's dispersal latency. |
+| `--memstore.get-latency` | `0` | `$EIGENDA_PROXY_MEMSTORE_GET_LATENCY` | Artificial latency added for memstore backend to mimic EigenDA's retrieval latency. |
 | `--metrics.addr` | `"0.0.0.0"` | `$EIGENDA_PROXY_METRICS_ADDR` | Metrics listening address. |
 | `--metrics.enabled` | `false` | `$EIGENDA_PROXY_METRICS_ENABLED` | Enable the metrics server. |
 | `--metrics.port` | `7300` | `$EIGENDA_PROXY_METRICS_PORT` | Metrics listening port. |

--- a/server/config.go
+++ b/server/config.go
@@ -464,25 +464,25 @@ func CLIFlags() []cli.Flag {
 		&cli.BoolFlag{
 			Name:    MemstoreFlagName,
 			Usage:   "Whether to use mem-store for DA logic.",
-			EnvVars: []string{"MEMSTORE_ENABLED"},
+			EnvVars: prefixEnvVars("MEMSTORE_ENABLED"),
 		},
 		&cli.DurationFlag{
 			Name:    MemstoreExpirationFlagName,
 			Usage:   "Duration that a mem-store blob/commitment pair are allowed to live.",
 			Value:   25 * time.Minute,
-			EnvVars: []string{"MEMSTORE_EXPIRATION"},
+			EnvVars: prefixEnvVars("MEMSTORE_EXPIRATION"),
 		},
 		&cli.DurationFlag{
 			Name:    MemstorePutLatencyFlagName,
 			Usage:   "Artificial latency added for memstore backend to mimic EigenDA's dispersal latency.",
 			Value:   0,
-			EnvVars: []string{"MEMSTORE_PUT_LATENCY"},
+			EnvVars: prefixEnvVars("MEMSTORE_PUT_LATENCY"),
 		},
 		&cli.DurationFlag{
 			Name:    MemstoreGetLatencyFlagName,
 			Usage:   "Artificial latency added for memstore backend to mimic EigenDA's retrieval latency.",
 			Value:   0,
-			EnvVars: []string{"MEMSTORE_GET_LATENCY"},
+			EnvVars: prefixEnvVars("MEMSTORE_GET_LATENCY"),
 		},
 		&cli.StringSliceFlag{
 			Name:    FallbackTargets,


### PR DESCRIPTION
Needed for consistency with all other flags. For some reason MEMSTORE flags are the only ones without the EIGENDA_PROXY flag.
<img width="921" alt="image" src="https://github.com/user-attachments/assets/44474304-e20c-4198-ae2f-8d4ba6eff12b">

## Breaking
This is a breaking change for anyone who was running the proxy using the env var flags. They will need to add the prefix so we should communicate this change.