### PR TITLE
fix: wrap crit entrypoint error for easier debugging

### DIFF
--- a/cmd/server/entrypoint.go
+++ b/cmd/server/entrypoint.go
@@ -34,7 +34,7 @@ func StartProxySvr(cliCtx *cli.Context) error {
 	server := server.NewServer(cliCtx.String(server.ListenAddrFlagName), cliCtx.Int(server.PortFlagName), daRouter, log, m)
 
 	if err := server.Start(); err != nil {
-		return fmt.Errorf("failed to start the DA server")
+		return fmt.Errorf("failed to start the DA server: %w", err)
 	}
 
 	log.Info("Started EigenDA proxy server")


### PR DESCRIPTION
Compare before:
```
CRIT [09-16|12:30:18.362] Application failed                       role=eigenda_proxy message="failed to start the DA server"
```
to after:
```
CRIT [09-16|12:32:56.571] Application failed                       role=eigenda_proxy message="failed to start the DA server: failed to listen: listen tcp 0.0.0.0:3100: bind: address already in use"
```