### PR TITLE
Fix HTTP `PUT` requests panicking with nil-pointer deref when no S3 configured

### DIFF
--- a/store/router.go
+++ b/store/router.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"sync"
 
 	"github.com/Layr-Labs/eigenda-proxy/commitments"
@@ -38,15 +39,20 @@ type Router struct {
 
 func NewRouter(eigenda KeyGeneratedStore, s3 PrecomputedKeyStore, l log.Logger,
 	caches []PrecomputedKeyStore, fallbacks []PrecomputedKeyStore) (IRouter, error) {
-	return &Router{
+	r := &Router{
 		log:          l,
-		eigenda:      eigenda,
-		s3:           s3,
 		caches:       caches,
 		cacheLock:    sync.RWMutex{},
 		fallbacks:    fallbacks,
 		fallbackLock: sync.RWMutex{},
-	}, nil
+	}
+	if !reflect.ValueOf(s3).IsNil() {
+		r.s3 = s3
+	}
+	if !reflect.ValueOf(eigenda).IsNil() {
+		r.eigenda = eigenda
+	}
+	return r, nil
 }
 
 // Get ... fetches a value from a storage backend based on the (commitment mode, type)


### PR DESCRIPTION
## Problem
If the CLI is not configured with S3 storage options, HTTP handler for `PUT`ing a keyed commitment will panic with a nil pointer dereference:
```
f1
eigenda-proxy-1      | t=2024-09-17T08:14:51+0000 lvl=info msg="http: panic serving 172.18.0.5:54058: runtime error: invalid memory address or nil pointer dereference\ngoroutine 1628 [running]:\nnet/http.(*conn).serve.func1()\n\t/usr/local/go/src/net/http/server.go:1868 +0xb0\npanic({0x1117f00?, 0x1ef1a90?})\n\t/usr/local/go/src/runtime/panic.go:920 +0x26c\ngithub.com/Layr-Labs/eigenda-proxy/store.(*S3Store).Put(0x0, {0x1679168, 0x4000633b30}, {0x40016f80f1, 0x20, 0x50?}, {0x4001798000, 0x9372, 0xa000})\n\t/app/store/s3.go:98 +0xe4\ngithub.com/Layr-Labs/eigenda-proxy/store.(*Router).putWithKey(0x400062e360, {0x1679168, 0x4000633b30}, {0x40016f80f1, 0x20, 0x4f}, {0x4001798000, 0x9372, 0xa000})\n\t/app/store/router.go:243 +0xd4\ngithub.com/Layr-Labs/eigenda-proxy/store.(*Router).Put(0x400062e360, {0x1679168, 0x4000633b30}, {0x12c272a?, 0x400084ee10?}, {0x40016f80f1, 0x20, 0x4f}, {0x4001798000, 0x9372, ...})\n\t/app/store/router.go:125 +0x254\ngithub.com/Layr-Labs/eigenda-proxy/server.(*Server).HandlePut(0x40006de240, {0x1675e10, 0x40014cf5e0}, 0x400137c200)\n\t/app/server/server.go:214 +0x390\ngithub.com/Layr-Labs/eigenda-proxy/server.(*Server).Start.WithMetrics.func4({0x1675e10, 0x40014cf5e0}, 0x400137c200)\n\t/app/server/server.go:78 +0x78\ngithub.com/Layr-Labs/eigenda-proxy/server.(*Server).Start.WithLogging.func5({0x1675e10, 0x40014cf5e0}, 0x400137c200)\n\t/app/server/server.go:90 +0x144\nnet/http.HandlerFunc.ServeHTTP(0x400609d42c?, {0x1675e10?, 0x40014cf5e0?}, 0x4000086af0?)\n\t/usr/local/go/src/net/http/server.go:2136 +0x38\nnet/http.(*ServeMux).ServeHTTP(0x10?, {0x1675e10, 0x40014cf5e0}, 0x400137c200)\n\t/usr/local/go/src/net/http/server.go:2514 +0x144\nnet/http.serverHandler.ServeHTTP({0x16737b8?}, {0x1675e10?, 0x40014cf5e0?}, 0x6?)\n\t/usr/local/go/src/net/http/server.go:2938 +0xbc\nnet/http.(*conn).serve(0x40015da360, {0x1679130, 0x40006a8f90})\n\t/usr/local/go/src/net/http/server.go:2009 +0x518\ncreated by net/http.(*Server).Serve in goroutine 67\n\t/usr/local/go/src/net/http/server.go:3086 +0x4cc" role=eigenda_proxy
```
## Cause of the problem

If the S3 storage options are not given, the `s3` variable will be a nil'ed pointer, which is passed to the `Router` initializer.

https://github.com/Layr-Labs/eigenda-proxy/blob/b1ec82177365669c17b67288b12209cae27d8df3/server/load_store.go#L45-L54

Unintuitively however, for example this check in the `putWithKey` handler does not evaluate to true when no S3 store is configured:
https://github.com/Layr-Labs/eigenda-proxy/blob/b1ec82177365669c17b67288b12209cae27d8df3/store/router.go#L234-L236
Once a method is called on the nil'ed S3 store pointer, the HTTP-handler's go-routine crashes with a nil-pointer dereference.

In go checking for `if foo == nil`, when `foo` is an interface type is unintuitive. If the variable is explicitly assigned, even assigning a nil'ed pointer value of a type implementing the interface will result in `bool(a == nil) == false`. Instead, reflection has to be used to peek into the underlying value of the variable to check for nil.

See [this go-playground for example](https://go.dev/play/p/XUU6NC-tuH2)

## Changes proposed


In this PR, the `eigenda` and `s3` store fields of the router are only explicitly assigned, if the reflection confirms that the underlying value of the implementing type does not evaluate to nil.
This will result the fields evaluating to e.g. `bool(r.s3 == nil) == true`, when no S3 storage is passed in as CLI option.

## Note to reviewers
The behavior has been only manually tested by not passing S3 options to the CLI and starting an AltDA enabled Optimsim batcher connected to the proxy.
