### PR TITLE
Fix metric middleware panic

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -99,7 +99,7 @@ func NewMetrics(subsystem string) *Metrics {
 			Buckets: prometheus.ExponentialBucketsRange(0.05, 1200, 20),
 			Help:    "Histogram of HTTP server request durations",
 		}, []string{
-			"method", "commitment_mode", "DA_cert_version", // no status on histograms because those are very expensive
+			"method", // no status on histograms because those are very expensive
 		}),
 		registry: registry,
 		factory:  factory,

--- a/server/server.go
+++ b/server/server.go
@@ -146,19 +146,23 @@ func (svr *Server) Health(w http.ResponseWriter, _ *http.Request) error {
 	return nil
 }
 
+// HandleGet handles the GET request for commitments.
+// Note: even when an error is returned, the commitment meta is still returned,
+// because it is needed for metrics (see the WithMetrics middleware).
+// TODO: we should change this behavior and instead use a custom error that contains the commitment meta.
 func (svr *Server) HandleGet(w http.ResponseWriter, r *http.Request) (commitments.CommitmentMeta, error) {
 	meta, err := ReadCommitmentMeta(r)
 	if err != nil {
 		err = fmt.Errorf("invalid commitment mode: %w", err)
 		svr.WriteBadRequest(w, err)
-		return commitments.CommitmentMeta{}, err
+		return meta, err
 	}
 	key := path.Base(r.URL.Path)
 	comm, err := commitments.StringToDecodedCommitment(key, meta.Mode)
 	if err != nil {
 		err = fmt.Errorf("failed to decode commitment from key %v (commitment mode %v): %w", key, meta.Mode, err)
 		svr.WriteBadRequest(w, err)
-		return commitments.CommitmentMeta{}, err
+		return meta, err
 	}
 
 	input, err := svr.router.Get(r.Context(), comm, meta.Mode)
@@ -169,26 +173,30 @@ func (svr *Server) HandleGet(w http.ResponseWriter, r *http.Request) (commitment
 		} else {
 			svr.WriteInternalError(w, err)
 		}
-		return commitments.CommitmentMeta{}, err
+		return meta, err
 	}
 
 	svr.WriteResponse(w, input)
 	return meta, nil
 }
 
+// HandlePut handles the PUT request for commitments.
+// Note: even when an error is returned, the commitment meta is still returned, 
+// because it is needed for metrics (see the WithMetrics middleware).
+// TODO: we should change this behavior and instead use a custom error that contains the commitment meta.
 func (svr *Server) HandlePut(w http.ResponseWriter, r *http.Request) (commitments.CommitmentMeta, error) {
 	meta, err := ReadCommitmentMeta(r)
 	if err != nil {
 		err = fmt.Errorf("invalid commitment mode: %w", err)
 		svr.WriteBadRequest(w, err)
-		return commitments.CommitmentMeta{}, err
+		return meta, err
 	}
 
 	input, err := io.ReadAll(r.Body)
 	if err != nil {
 		err = fmt.Errorf("failed to read request body: %w", err)
 		svr.WriteBadRequest(w, err)
-		return commitments.CommitmentMeta{}, err
+		return meta, err
 	}
 
 	key := path.Base(r.URL.Path)
@@ -199,7 +207,7 @@ func (svr *Server) HandlePut(w http.ResponseWriter, r *http.Request) (commitment
 		if err != nil {
 			err = fmt.Errorf("failed to decode commitment from key %v (commitment mode %v): %w", key, meta.Mode, err)
 			svr.WriteBadRequest(w, err)
-			return commitments.CommitmentMeta{}, err
+			return meta, err
 		}
 	}
 
@@ -214,7 +222,7 @@ func (svr *Server) HandlePut(w http.ResponseWriter, r *http.Request) (commitment
 	if err != nil {
 		err = fmt.Errorf("failed to encode commitment %v (commitment mode %v): %w", commitment, meta.Mode, err)
 		svr.WriteInternalError(w, err)
-		return commitments.CommitmentMeta{}, err
+		return meta, err
 	}
 
 	svr.log.Info(fmt.Sprintf("write commitment: %x\n", comm))

--- a/server/server.go
+++ b/server/server.go
@@ -181,7 +181,7 @@ func (svr *Server) HandleGet(w http.ResponseWriter, r *http.Request) (commitment
 }
 
 // HandlePut handles the PUT request for commitments.
-// Note: even when an error is returned, the commitment meta is still returned, 
+// Note: even when an error is returned, the commitment meta is still returned,
 // because it is needed for metrics (see the WithMetrics middleware).
 // TODO: we should change this behavior and instead use a custom error that contains the commitment meta.
 func (svr *Server) HandlePut(w http.ResponseWriter, r *http.Request) (commitments.CommitmentMeta, error) {


### PR DESCRIPTION
Recent metric changes were causing panics that weren't caught in tests because the tests never use the metrics and logs middlewares. Added testing for those, and fixed the panic.

<!-- If your PR fixes an open issue, use `Closes #NNN` to link your PR with the
issue, replacing `#NNN` with the issue number you are fixing -->

## Fixes Issue

<!-- Example: Closes #NNN -->
Fixes #

## Changes proposed

<!-- List all the proposed changes in your PR -->
<!-- Add the screenshots of the changes below if applicable -->

### Screenshots (Optional)

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
