### PR TITLE
fix: custom error wrapped around error and commitment meta

### DIFF
--- a/server/errors.go
+++ b/server/errors.go
@@ -1,0 +1,33 @@
+package server
+
+import (
+	"fmt"
+
+	"github.com/Layr-Labs/eigenda-proxy/commitments"
+)
+
+// HandlerError is an interface that can be either a simple error or a MetaError
+type HandlerError interface {
+	error
+	isHandlerError() // marker method
+}
+
+// MetaError includes both an error and commitment metadata
+type MetaError struct {
+	Err  error
+	Meta commitments.CommitmentMeta
+}
+
+func (me MetaError) Error() string {
+	return fmt.Sprintf("Error: %s (Mode: %s, CertVersion: %b)",
+		me.Err.Error(),
+		me.Meta.Mode,
+		me.Meta.CertVersion)
+}
+
+func (MetaError) isHandlerError() {}
+
+// NewMetaError creates a new MetaError
+func NewMetaError(err error, meta commitments.CommitmentMeta) HandlerError {
+	return MetaError{Err: err, Meta: meta}
+}

--- a/server/errors.go
+++ b/server/errors.go
@@ -6,12 +6,6 @@ import (
 	"github.com/Layr-Labs/eigenda-proxy/commitments"
 )
 
-// HandlerError is an interface that can be either a simple error or a MetaError
-type HandlerError interface {
-	error
-	isHandlerError() // marker method
-}
-
 // MetaError includes both an error and commitment metadata
 type MetaError struct {
 	Err  error
@@ -25,9 +19,7 @@ func (me MetaError) Error() string {
 		me.Meta.CertVersion)
 }
 
-func (MetaError) isHandlerError() {}
-
 // NewMetaError creates a new MetaError
-func NewMetaError(err error, meta commitments.CommitmentMeta) HandlerError {
+func NewMetaError(err error, meta commitments.CommitmentMeta) MetaError {
 	return MetaError{Err: err, Meta: meta}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -67,9 +67,9 @@ func WithMetrics(handleFn func(http.ResponseWriter, *http.Request) (commitments.
 
 		meta, err := handleFn(w, r)
 		if err != nil {
-			// check if the error is a measured error
-			if meta, ok := err.(MetaError); ok {
-				recordDur(w.Header().Get("status"), string(meta.Meta.Mode), string(meta.Meta.CertVersion))
+			var metaErr MetaError
+			if errors.As(err, &metaErr) {
+				recordDur(w.Header().Get("status"), string(metaErr.Meta.Mode), string(metaErr.Meta.CertVersion))
 			} else {
 				recordDur(w.Header().Get("status"), string("NoCommitmentMode"), string("NoCertVersion"))
 			}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -85,7 +85,7 @@ func TestGetHandler(t *testing.T) {
 			expectedCode:           http.StatusInternalServerError,
 			expectedBody:           "",
 			expectError:            true,
-			expectedCommitmentMeta: commitments.CommitmentMeta{Mode: commitments.OptimismGeneric, CertVersion: 0},
+			expectedCommitmentMeta: commitments.CommitmentMeta{},
 		},
 		{
 			name: "Success - OP Keccak256",
@@ -107,7 +107,7 @@ func TestGetHandler(t *testing.T) {
 			expectedCode:           http.StatusInternalServerError,
 			expectedBody:           "",
 			expectError:            true,
-			expectedCommitmentMeta: commitments.CommitmentMeta{Mode: commitments.OptimismAltDA, CertVersion: 0},
+			expectedCommitmentMeta: commitments.CommitmentMeta{},
 		},
 		{
 			name: "Success - OP Alt-DA",
@@ -131,9 +131,9 @@ func TestGetHandler(t *testing.T) {
 
 			meta, err := server.HandleGet(rec, req)
 			if tt.expectError {
-				require.Error(t, err)
+				require.Error(t, err.Err)
 			} else {
-				require.NoError(t, err)
+				require.NoError(t, err.Err)
 			}
 
 			require.Equal(t, tt.expectedCode, rec.Code)
@@ -217,11 +217,10 @@ func TestPutHandler(t *testing.T) {
 			mockBehavior: func() {
 				mockRouter.EXPECT().Put(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("internal error"))
 			},
-			expectedCode: http.StatusInternalServerError,
-			expectedBody: "",
-			expectError:  true,
-			// certification version is the third byte of the body, in this case it's "m"
-			expectedCommitmentMeta: commitments.CommitmentMeta{Mode: commitments.OptimismAltDA, CertVersion: 0},
+			expectedCode:           http.StatusInternalServerError,
+			expectedBody:           "",
+			expectError:            true,
+			expectedCommitmentMeta: commitments.CommitmentMeta{},
 		},
 		{
 			name: "Success OP Mode Alt-DA",
@@ -270,9 +269,9 @@ func TestPutHandler(t *testing.T) {
 
 			meta, err := server.HandlePut(rec, req)
 			if tt.expectError {
-				require.Error(t, err)
+				require.Error(t, err.Err)
 			} else {
-				require.NoError(t, err)
+				require.NoError(t, err.Err)
 			}
 			require.Equal(t, tt.expectedCode, rec.Code)
 			if !tt.expectError {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -131,9 +131,9 @@ func TestGetHandler(t *testing.T) {
 
 			meta, err := server.HandleGet(rec, req)
 			if tt.expectError {
-				require.Error(t, err.Err)
+				require.Error(t, err)
 			} else {
-				require.NoError(t, err.Err)
+				require.NoError(t, err)
 			}
 
 			require.Equal(t, tt.expectedCode, rec.Code)
@@ -269,9 +269,9 @@ func TestPutHandler(t *testing.T) {
 
 			meta, err := server.HandlePut(rec, req)
 			if tt.expectError {
-				require.Error(t, err.Err)
+				require.Error(t, err)
 			} else {
-				require.NoError(t, err.Err)
+				require.NoError(t, err)
 			}
 			require.Equal(t, tt.expectedCode, rec.Code)
 			if !tt.expectError {


### PR DESCRIPTION
Added a `HandlerError` type to contain error and commitment meta (mode and version) for metrics