### PR TITLE
fix: HandlePut uses hardcoded default version

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -191,6 +191,10 @@ func (svr *Server) HandlePut(w http.ResponseWriter, r *http.Request) (commitment
 		svr.WriteBadRequest(w, err)
 		return meta, err
 	}
+	// ReadCommitmentMeta function invoked inside HandlePut will not return a valid certVersion
+	// Current simple fix is using the hardcoded default value of 0 (also the only supported value)
+	//TODO: smarter decode needed when there's more than one version
+	meta.CertVersion = byte(commitments.CertV0)
 
 	input, err := io.ReadAll(r.Body)
 	if err != nil {


### PR DESCRIPTION
Bowen explained that if `HandlePut` is writing a request of commitment mode `op kaccek256`, the OP daclient will set the base part of the query as the hash digest, and not follow the commitment schema described in the eigenda-proxy README. We can't simply decode the request for `HandlePut`.

Since there's only one `CertEncodingCommitment` supported by EigenDA right now, the simple fix is to use default 0x0. The override happens after `ReadCommitmentMeta` in `HandlePut` and not inside `ReadCommitmentMeta` because `HandleGet` method is okay.