### PR TITLE
Fix config checker logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ clean:
 	rm bin/eigenda-proxy
 
 test:
-	go test -v ./... -parallel 4 
+	go test ./... -parallel 4 
 
 e2e-test: stop-minio stop-redis run-minio run-redis
 	$(E2ETEST) && \

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ In order to disperse to the EigenDA network in production, or at high throughput
 | `--eigenda-custom-quorum-ids` |  | `$EIGENDA_PROXY_CUSTOM_QUORUM_IDS` | Custom quorum IDs for writing blobs. Should not include default quorums 0 or 1. |
 | `--eigenda-disable-point-verification-mode` | `false` | `$EIGENDA_PROXY_DISABLE_POINT_VERIFICATION_MODE` | Disable point verification mode. This mode performs IFFT on data before writing and FFT on data after reading. Disabling requires supplying the entire blob for verification against the KZG commitment. |
 | `--eigenda-disable-tls` | `false` | `$EIGENDA_PROXY_GRPC_DISABLE_TLS` | Disable TLS for gRPC communication with the EigenDA disperser. Default is false. |
+| --eigenda-cert-verification-enabled | `false` | `$EIGENDA_PROXY_CERT_VERIFICATION_ENABLED` | Whether to verify certificates received from EigenDA disperser. |
 | `--eigenda-disperser-rpc` |  | `$EIGENDA_PROXY_EIGENDA_DISPERSER_RPC` | RPC endpoint of the EigenDA disperser. |
+| `--eigenda-svc-manager-addr` |  | `$EIGENDA_PROXY_SERVICE_MANAGER_ADDR` | The deployed EigenDA service manager address. The list can be found here: https://github.com/Layr-Labs/eigenlayer-middleware/?tab=readme-ov-file#current-mainnet-deployment |
 | `--eigenda-eth-confirmation-depth` | `-1` | `$EIGENDA_PROXY_ETH_CONFIRMATION_DEPTH` | The number of Ethereum blocks of confirmation that the DA bridging transaction must have before it is assumed by the proxy to be final. If set negative the proxy will always wait for blob finalization. |
 | `--eigenda-eth-rpc` |  | `$EIGENDA_PROXY_ETH_RPC` | JSON RPC node endpoint for the Ethereum network used for finalizing DA blobs. See available list here: https://docs.eigenlayer.xyz/eigenda/networks/ |
 | `--eigenda-g1-path` | `"resources/g1.point"` | `$EIGENDA_PROXY_TARGET_KZG_G1_PATH` | Directory path to g1.point file. |
@@ -41,7 +43,6 @@ In order to disperse to the EigenDA network in production, or at high throughput
 | `--eigenda-signer-private-key-hex` |  | `$EIGENDA_PROXY_SIGNER_PRIVATE_KEY_HEX` | Hex-encoded signer private key. This key should not be associated with an Ethereum address holding any funds. |
 | `--eigenda-status-query-retry-interval` | `5s` | `$EIGENDA_PROXY_STATUS_QUERY_INTERVAL` | Interval between retries when awaiting network blob finalization. Default is 5 seconds. |
 | `--eigenda-status-query-timeout` | `30m0s` | `$EIGENDA_PROXY_STATUS_QUERY_TIMEOUT` | Duration to wait for a blob to finalize after being sent for dispersal. Default is 30 minutes. |
-| `--eigenda-svc-manager-addr` |  | `$EIGENDA_PROXY_SERVICE_MANAGER_ADDR` | The deployed EigenDA service manager address. The list can be found here: https://github.com/Layr-Labs/eigenlayer-middleware/?tab=readme-ov-file#current-mainnet-deployment |
 | `--log.color` | `false` | `$EIGENDA_PROXY_LOG_COLOR` | Color the log output if in terminal mode. |
 | `--log.format` | `text` | `$EIGENDA_PROXY_LOG_FORMAT` | Format the log output. Supported formats: 'text', 'terminal', 'logfmt', 'json', 'json-pretty'. |
 | `--log.level` | `INFO` | `$EIGENDA_PROXY_LOG_LEVEL` | The lowest log level that will be output. |

--- a/server/config.go
+++ b/server/config.go
@@ -26,6 +26,7 @@ const (
 	PutBlobEncodingVersionFlagName       = "eigenda-put-blob-encoding-version"
 	DisablePointVerificationModeFlagName = "eigenda-disable-point-verification-mode"
 
+	// cert verification flags
 	CertVerificationEnabledFlagName = "eigenda-cert-verification-enabled"
 	EthRPCFlagName                  = "eigenda-eth-rpc"
 	SvcManagerAddrFlagName          = "eigenda-svc-manager-addr"
@@ -456,7 +457,7 @@ func CLIFlags() []cli.Flag {
 		},
 		&cli.BoolFlag{
 			Name:    CertVerificationEnabledFlagName,
-			Usage:   "Whether to verify certificates from EigenDA. If false, the DA-proxy will not verify certificates and will not require an Ethereum RPC endpoint.",
+			Usage:   "Whether to verify certificates received from EigenDA disperser.",
 			EnvVars: prefixEnvVars("CERT_VERIFICATION_ENABLED"),
 			// TODO: ideally we'd want this to be turned on by default when eigenda backend is used (memstore.enabled=false)
 			Value: false,

--- a/server/config.go
+++ b/server/config.go
@@ -246,16 +246,20 @@ func (cfg *Config) Check() error {
 		return fmt.Errorf("max blob length is 0")
 	}
 
-	if cfg.SvcManagerAddr != "" && cfg.EthRPC == "" {
-		return fmt.Errorf("svc manager address is set, but Eth RPC is not set")
-	}
+	// memstore not enabled means we use eigenda as a backend, which requires these fields to be set
+	if !cfg.MemstoreEnabled {
+		if cfg.ClientConfig.RPC == "" {
+			return fmt.Errorf("eigenda disperser rpc url is not set")
+		}
 
-	if cfg.EthRPC != "" && cfg.SvcManagerAddr == "" {
-		return fmt.Errorf("eth rpc is set, but svc manager address is not set")
-	}
+		if cfg.EthRPC == "" {
+			return fmt.Errorf("eth rpc is not set")
+		}
 
-	if cfg.EthConfirmationDepth >= 0 && (cfg.SvcManagerAddr == "" || cfg.EthRPC == "") {
-		return fmt.Errorf("eth confirmation depth is set for certificate verification, but Eth RPC or SvcManagerAddr is not set")
+		if cfg.SvcManagerAddr == "" {
+			return fmt.Errorf("svc manager address is not set")
+		}
+
 	}
 
 	if cfg.S3Config.S3CredentialType == store.S3CredentialUnknown && cfg.S3Config.Endpoint != "" {
@@ -269,10 +273,6 @@ func (cfg *Config) Check() error {
 
 	if cfg.RedisCfg.Endpoint == "" && cfg.RedisCfg.Password != "" {
 		return fmt.Errorf("redis password is set, but endpoint is not")
-	}
-
-	if !cfg.MemstoreEnabled && cfg.ClientConfig.RPC == "" {
-		return fmt.Errorf("eigenda disperser rpc url is not set")
 	}
 
 	err = cfg.checkTargets(cfg.FallbackTargets)

--- a/server/config.go
+++ b/server/config.go
@@ -259,7 +259,6 @@ func (cfg *Config) Check() error {
 		if cfg.SvcManagerAddr == "" {
 			return fmt.Errorf("svc manager address is not set")
 		}
-
 	}
 
 	if cfg.S3Config.S3CredentialType == store.S3CredentialUnknown && cfg.S3Config.Endpoint != "" {

--- a/server/config.go
+++ b/server/config.go
@@ -17,9 +17,6 @@ import (
 const (
 	// eigenda client flags
 	EigenDADisperserRPCFlagName          = "eigenda-disperser-rpc"
-	EthRPCFlagName                       = "eigenda-eth-rpc"
-	SvcManagerAddrFlagName               = "eigenda-svc-manager-addr"
-	EthConfirmationDepthFlagName         = "eigenda-eth-confirmation-depth"
 	StatusQueryRetryIntervalFlagName     = "eigenda-status-query-retry-interval"
 	StatusQueryTimeoutFlagName           = "eigenda-status-query-timeout"
 	DisableTLSFlagName                   = "eigenda-disable-tls"
@@ -28,6 +25,11 @@ const (
 	SignerPrivateKeyHexFlagName          = "eigenda-signer-private-key-hex"
 	PutBlobEncodingVersionFlagName       = "eigenda-put-blob-encoding-version"
 	DisablePointVerificationModeFlagName = "eigenda-disable-point-verification-mode"
+
+	CertVerificationEnabledFlagName = "eigenda-cert-verification-enabled"
+	EthRPCFlagName                  = "eigenda-eth-rpc"
+	SvcManagerAddrFlagName          = "eigenda-svc-manager-addr"
+	EthConfirmationDepthFlagName    = "eigenda-eth-confirmation-depth"
 
 	// kzg flags
 	G1PathFlagName        = "eigenda-g1-path"
@@ -79,10 +81,13 @@ type Config struct {
 	// the blob encoding version to use when writing blobs from the high level interface.
 	PutBlobEncodingVersion codecs.BlobEncodingVersion
 
-	// eth vars
-	EthRPC               string
-	SvcManagerAddr       string
-	EthConfirmationDepth int64
+	// eth verification vars
+	// TODO: right now verification and confirmation depth are tightly coupled
+	//       we should decouple them
+	CertVerificationEnabled bool
+	EthRPC                  string
+	SvcManagerAddr          string
+	EthConfirmationDepth    int64
 
 	// kzg vars
 	CacheDir         string
@@ -143,18 +148,11 @@ func (cfg *Config) VerificationCfg() *verify.Config {
 		NumWorker:       uint64(runtime.GOMAXPROCS(0)), // #nosec G115
 	}
 
-	if cfg.EthRPC == "" || cfg.SvcManagerAddr == "" {
-		return &verify.Config{
-			Verify:    false,
-			KzgConfig: kzgCfg,
-		}
-	}
-
 	return &verify.Config{
-		Verify:               true,
+		KzgConfig:            kzgCfg,
+		VerifyCerts:          cfg.CertVerificationEnabled,
 		RPCURL:               cfg.EthRPC,
 		SvcManagerAddr:       cfg.SvcManagerAddr,
-		KzgConfig:            kzgCfg,
 		EthConfirmationDepth: uint64(cfg.EthConfirmationDepth), // #nosec G115
 	}
 }
@@ -189,19 +187,20 @@ func ReadConfig(ctx *cli.Context) Config {
 			PutBlobEncodingVersion:       codecs.BlobEncodingVersion(ctx.Uint(PutBlobEncodingVersionFlagName)),
 			DisablePointVerificationMode: ctx.Bool(DisablePointVerificationModeFlagName),
 		},
-		G1Path:                 ctx.String(G1PathFlagName),
-		G2PowerOfTauPath:       ctx.String(G2TauFlagName),
-		CacheDir:               ctx.String(CachePathFlagName),
-		MaxBlobLength:          ctx.String(MaxBlobLengthFlagName),
-		SvcManagerAddr:         ctx.String(SvcManagerAddrFlagName),
-		EthRPC:                 ctx.String(EthRPCFlagName),
-		EthConfirmationDepth:   ctx.Int64(EthConfirmationDepthFlagName),
-		MemstoreEnabled:        ctx.Bool(MemstoreFlagName),
-		MemstoreBlobExpiration: ctx.Duration(MemstoreExpirationFlagName),
-		MemstoreGetLatency:     ctx.Duration(MemstoreGetLatencyFlagName),
-		MemstorePutLatency:     ctx.Duration(MemstorePutLatencyFlagName),
-		FallbackTargets:        ctx.StringSlice(FallbackTargets),
-		CacheTargets:           ctx.StringSlice(CacheTargets),
+		G1Path:                  ctx.String(G1PathFlagName),
+		G2PowerOfTauPath:        ctx.String(G2TauFlagName),
+		CacheDir:                ctx.String(CachePathFlagName),
+		CertVerificationEnabled: ctx.Bool(CertVerificationEnabledFlagName),
+		MaxBlobLength:           ctx.String(MaxBlobLengthFlagName),
+		SvcManagerAddr:          ctx.String(SvcManagerAddrFlagName),
+		EthRPC:                  ctx.String(EthRPCFlagName),
+		EthConfirmationDepth:    ctx.Int64(EthConfirmationDepthFlagName),
+		MemstoreEnabled:         ctx.Bool(MemstoreFlagName),
+		MemstoreBlobExpiration:  ctx.Duration(MemstoreExpirationFlagName),
+		MemstoreGetLatency:      ctx.Duration(MemstoreGetLatencyFlagName),
+		MemstorePutLatency:      ctx.Duration(MemstorePutLatencyFlagName),
+		FallbackTargets:         ctx.StringSlice(FallbackTargets),
+		CacheTargets:            ctx.StringSlice(CacheTargets),
 	}
 	// the eigenda client can only wait for 0 confirmations or finality
 	// the da-proxy has a more fine-grained notion of confirmation depth
@@ -246,18 +245,21 @@ func (cfg *Config) Check() error {
 		return fmt.Errorf("max blob length is 0")
 	}
 
-	// memstore not enabled means we use eigenda as a backend, which requires these fields to be set
 	if !cfg.MemstoreEnabled {
 		if cfg.ClientConfig.RPC == "" {
-			return fmt.Errorf("eigenda disperser rpc url is not set")
+			return fmt.Errorf("using eigenda backend (memstore.enabled=false) but eigenda disperser rpc url is not set")
 		}
+	}
 
+	if cfg.CertVerificationEnabled {
+		if cfg.MemstoreEnabled {
+			return fmt.Errorf("cannot enable cert verification when memstore is enabled")
+		}
 		if cfg.EthRPC == "" {
-			return fmt.Errorf("eth rpc is not set")
+			return fmt.Errorf("cert verification enabled but eth rpc is not set")
 		}
-
 		if cfg.SvcManagerAddr == "" {
-			return fmt.Errorf("svc manager address is not set")
+			return fmt.Errorf("cert verification enabled but svc manager address is not set")
 		}
 	}
 
@@ -452,19 +454,31 @@ func CLIFlags() []cli.Flag {
 			EnvVars: prefixEnvVars("TARGET_CACHE_PATH"),
 			Value:   "resources/SRSTables/",
 		},
+		&cli.BoolFlag{
+			Name:    CertVerificationEnabledFlagName,
+			Usage:   "Whether to verify certificates from EigenDA. If false, the DA-proxy will not verify certificates and will not require an Ethereum RPC endpoint.",
+			EnvVars: prefixEnvVars("CERT_VERIFICATION_ENABLED"),
+			// TODO: ideally we'd want this to be turned on by default when eigenda backend is used (memstore.enabled=false)
+			Value: false,
+		},
 		&cli.StringFlag{
-			Name:    EthRPCFlagName,
-			Usage:   "JSON RPC node endpoint for the Ethereum network used for finalizing DA blobs. See available list here: https://docs.eigenlayer.xyz/eigenda/networks/",
+			Name: EthRPCFlagName,
+			Usage: "JSON RPC node endpoint for the Ethereum network used for finalizing DA blobs.\n" +
+				"See available list here: https://docs.eigenlayer.xyz/eigenda/networks/\n" +
+				fmt.Sprintf("Mandatory when %s is true.", CertVerificationEnabledFlagName),
 			EnvVars: prefixEnvVars("ETH_RPC"),
 		},
 		&cli.StringFlag{
-			Name:    SvcManagerAddrFlagName,
-			Usage:   "The deployed EigenDA service manager address. The list can be found here: https://github.com/Layr-Labs/eigenlayer-middleware/?tab=readme-ov-file#current-mainnet-deployment",
+			Name: SvcManagerAddrFlagName,
+			Usage: "The deployed EigenDA service manager address.\n" +
+				"The list can be found here: https://github.com/Layr-Labs/eigenlayer-middleware/?tab=readme-ov-file#current-mainnet-deployment\n" +
+				fmt.Sprintf("Mandatory when %s is true.", CertVerificationEnabledFlagName),
 			EnvVars: prefixEnvVars("SERVICE_MANAGER_ADDR"),
 		},
 		&cli.Int64Flag{
-			Name:    EthConfirmationDepthFlagName,
-			Usage:   "The number of Ethereum blocks to wait before considering a submitted blob's DA batch submission confirmed. `0` means wait for inclusion only. `-1` means wait for finality.",
+			Name: EthConfirmationDepthFlagName,
+			Usage: "The number of Ethereum blocks to wait before considering a submitted blob's DA batch submission confirmed.\n" +
+				"`0` means wait for inclusion only. `-1` means wait for finality.",
 			EnvVars: prefixEnvVars("ETH_CONFIRMATION_DEPTH"),
 			Value:   -1,
 		},

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -71,37 +71,26 @@ func TestConfigVerification(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	t.Run("MissingSvcManagerAddr", func(t *testing.T) {
-		cfg := validCfg()
+	t.Run("EigenDABackend", func(t *testing.T) {
+		// when eigenDABackend is enabled (memstore.enabled = false),
+		// some extra fields are required.
+		t.Run("MissingSvcManagerAddr", func(t *testing.T) {
+			cfg := validCfg()
+			cfg.MemstoreEnabled = false
+			cfg.SvcManagerAddr = ""
 
-		cfg.EthRPC = "http://localhost:6969"
-		cfg.EthConfirmationDepth = 12
-		cfg.SvcManagerAddr = ""
+			err := cfg.Check()
+			require.Error(t, err)
+		})
 
-		err := cfg.Check()
-		require.Error(t, err)
-	})
+		t.Run("MissingEthRPC", func(t *testing.T) {
+			cfg := validCfg()
+			cfg.MemstoreEnabled = false
+			cfg.EthRPC = ""
 
-	t.Run("MissingCertVerificationParams", func(t *testing.T) {
-		cfg := validCfg()
-
-		cfg.EthConfirmationDepth = 12
-		cfg.SvcManagerAddr = ""
-		cfg.EthRPC = "http://localhost:6969"
-
-		err := cfg.Check()
-		require.Error(t, err)
-	})
-
-	t.Run("MissingEthRPC", func(t *testing.T) {
-		cfg := validCfg()
-
-		cfg.EthConfirmationDepth = 12
-		cfg.SvcManagerAddr = "0x00000000123"
-		cfg.EthRPC = ""
-
-		err := cfg.Check()
-		require.Error(t, err)
+			err := cfg.Check()
+			require.Error(t, err)
+		})
 	})
 
 	t.Run("MissingS3AccessKeys", func(t *testing.T) {

--- a/server/load_store.go
+++ b/server/load_store.go
@@ -49,7 +49,7 @@ func LoadStoreRouter(ctx context.Context, cfg CLIConfig, log log.Logger) (store.
 		log.Info("Using S3 backend")
 		s3, err = store.NewS3(cfg.S3Config)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to create S3 store: %w", err)
 		}
 	}
 
@@ -58,7 +58,7 @@ func LoadStoreRouter(ctx context.Context, cfg CLIConfig, log log.Logger) (store.
 		// create Redis backend store
 		redis, err = store.NewRedisStore(&cfg.RedisCfg)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to create Redis store: %w", err)
 		}
 	}
 
@@ -68,10 +68,10 @@ func LoadStoreRouter(ctx context.Context, cfg CLIConfig, log log.Logger) (store.
 
 	verifier, err := verify.NewVerifier(vCfg, log)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create verifier: %w", err)
 	}
 
-	if vCfg.Verify {
+	if vCfg.VerifyCerts {
 		log.Info("Certificate verification with Ethereum enabled")
 	} else {
 		log.Warn("Verification disabled")

--- a/store/memory_test.go
+++ b/store/memory_test.go
@@ -27,7 +27,7 @@ func getDefaultMemStoreTestConfig() MemStoreConfig {
 
 func getDefaultVerifierTestConfig() *verify.Config {
 	return &verify.Config{
-		Verify: false,
+		VerifyCerts: false,
 		KzgConfig: &kzg.KzgConfig{
 			G1Path:          "../resources/g1.point",
 			G2PowerOf2Path:  "../resources/g2.point.powerOf2",

--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -40,8 +40,8 @@ func TestCommitmentVerification(t *testing.T) {
 	}
 
 	cfg := &Config{
-		Verify:    false,
-		KzgConfig: kzgConfig,
+		VerifyCerts: false,
+		KzgConfig:   kzgConfig,
 	}
 
 	v, err := NewVerifier(cfg, nil)
@@ -78,8 +78,8 @@ func TestCommitmentWithTooLargeBlob(t *testing.T) {
 	}
 
 	cfg := &Config{
-		Verify:    false,
-		KzgConfig: kzgConfig,
+		VerifyCerts: false,
+		KzgConfig:   kzgConfig,
 	}
 
 	v, err := NewVerifier(cfg, nil)


### PR DESCRIPTION
Since we merged the PR that fixed the `confDepth=-1` bug, now confDepth is always a non-negative number, so the conf checker is broken. Running `make run-memstore-server` results in this CRIT:
```
CRIT [09-19|21:18:50.564] Application failed                       role=eigenda_proxy message="eth confirmation depth is set for certificate verification, but Eth RPC or SvcManagerAddr is not set"
```

I changed the checks a bit arbitrarily... not super sure if it's correct, @epociask please take a good look. When using the memstore we don't need ethRPC or svsManagerAddr do we?

Tests are failing, waiting for correct semantic before changing them. Also removed the -v from `make test` because that prints too much garbage and is impossible to find the actual error when a test fails.