### PR TITLE
show response commitment

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -260,7 +260,7 @@ func (svr *Server) HandlePut(w http.ResponseWriter, r *http.Request) (commitment
 		}
 	}
 
-	svr.log.Info(fmt.Sprintf("write commitment: %x\n", comm))
+	svr.log.Info(fmt.Sprintf("response commitment: %x\n", responseCommit))
 	// write out encoded commitment
 	svr.WriteResponse(w, responseCommit)
 	return meta, nil


### PR DESCRIPTION
Current behavior after put, it shows an empty string
<img width="1697" alt="Screenshot 2024-09-20 at 1 19 23 PM" src="https://github.com/user-attachments/assets/94818a9c-26dd-4a0b-b5a8-083a5700a526">

This fix prints the response commitment
<img width="1723" alt="Screenshot 2024-09-20 at 1 36 23 PM" src="https://github.com/user-attachments/assets/4b193341-0794-4f98-b71f-b580e2a99a73">
