### PR TITLE
Added --s3.enable-tls flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ In order to disperse to the EigenDA network in production, or at high throughput
 | `--s3.bucket` |  | `$EIGENDA_PROXY_S3_BUCKET` | Bucket name for S3 storage. |
 | `--s3.path` |  | `$EIGENDA_PROXY_S3_PATH` | Bucket path for S3 storage. |
 | `--s3.endpoint` |  | `$EIGENDA_PROXY_S3_ENDPOINT` | Endpoint for S3 storage. |
+| `--s3.enable-tls` |  | `$EIGENDA_PROXY_S3_ENABLE_TLS` | Enable TLS connection to S3 endpoint. |
 | `--routing.fallback-targets` | `[]` | `$EIGENDA_PROXY_FALLBACK_TARGETS` | Fall back backend targets. Supports S3. | Backup storage locations to read from in the event of eigenda retrieval failure. |
 | `--routing.cache-targets` | `[]` | `$EIGENDA_PROXY_CACHE_TARGETS` | Caching targets. Supports S3. | Caches data to backend targets after dispersing to DA, retrieved from before trying read from EigenDA. |
 | `--s3.timeout` | `5s` | `$EIGENDA_PROXY_S3_TIMEOUT` | timeout for S3 storage operations (e.g. get, put) |

--- a/e2e/setup.go
+++ b/e2e/setup.go
@@ -81,6 +81,7 @@ func createS3Config(eigendaCfg server.Config) server.CLIConfig {
 		Bucket:          bucketName,
 		Path:            "",
 		Endpoint:        "localhost:4566",
+		EnableTLS:       false,
 		AccessKeySecret: "minioadmin",
 		AccessKeyID:     "minioadmin",
 		CredentialType:  s3.CredentialTypeStatic,

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -30,6 +30,7 @@ func validCfg() *Config {
 			Bucket:          "test-bucket",
 			Path:            "",
 			Endpoint:        "http://localhost:9000",
+			EnableTLS:       false,
 			AccessKeyID:     "access-key-id",
 			AccessKeySecret: "access-key-secret",
 		},

--- a/store/precomputed_key/s3/cli.go
+++ b/store/precomputed_key/s3/cli.go
@@ -33,14 +33,14 @@ func CLIFlags(envPrefix, category string) []cli.Flag {
 		&cli.StringFlag{
 			Name:     EndpointFlagName,
 			Usage:    "endpoint for S3 storage",
-			EnvVars:  withEnvPrefix(envPrefix, "S3_ENDPOINT"),
+			EnvVars:  withEnvPrefix(envPrefix, "ENDPOINT"),
 			Category: category,
 		},
 		&cli.BoolFlag{
 			Name:     EnableTLSFlagName,
 			Usage:    "enable TLS connection to S3 endpoint",
 			Value:    false,
-			EnvVars:  withEnvPrefix(envPrefix, "S3_ENABLE_TLS"),
+			EnvVars:  withEnvPrefix(envPrefix, "ENABLE_TLS"),
 			Category: category,
 		},
 		&cli.StringFlag{

--- a/store/precomputed_key/s3/cli.go
+++ b/store/precomputed_key/s3/cli.go
@@ -8,6 +8,7 @@ import (
 
 var (
 	EndpointFlagName        = withFlagPrefix("endpoint")
+	EnableTLSFlagName       = withFlagPrefix("enable-tls")
 	CredentialTypeFlagName  = withFlagPrefix("credential-type")
 	AccessKeyIDFlagName     = withFlagPrefix("access-key-id")     // #nosec G101
 	AccessKeySecretFlagName = withFlagPrefix("access-key-secret") // #nosec G101
@@ -35,9 +36,16 @@ func CLIFlags(envPrefix, category string) []cli.Flag {
 			EnvVars:  withEnvPrefix(envPrefix, "S3_ENDPOINT"),
 			Category: category,
 		},
+		&cli.BoolFlag{
+			Name:     EnableTLSFlagName,
+			Usage:    "enable TLS connection to S3 endpoint",
+			Value:    false,
+			EnvVars:  withEnvPrefix(envPrefix, "S3_ENABLE_TLS"),
+			Category: category,
+		},
 		&cli.StringFlag{
 			Name:     CredentialTypeFlagName,
-			Usage:    "The way to authenticate to S3, options are [iam, static]",
+			Usage:    "the way to authenticate to S3, options are [iam, static]",
 			EnvVars:  withEnvPrefix(envPrefix, "CREDENTIAL_TYPE"),
 			Category: category,
 		},
@@ -86,6 +94,7 @@ func ReadConfig(ctx *cli.Context) Config {
 	return Config{
 		CredentialType:  StringToCredentialType(ctx.String(CredentialTypeFlagName)),
 		Endpoint:        ctx.String(EndpointFlagName),
+		EnableTLS:       ctx.Bool(EnableTLSFlagName),
 		AccessKeyID:     ctx.String(AccessKeyIDFlagName),
 		AccessKeySecret: ctx.String(AccessKeySecretFlagName),
 		Bucket:          ctx.String(BucketFlagName),

--- a/store/precomputed_key/s3/s3.go
+++ b/store/precomputed_key/s3/s3.go
@@ -39,6 +39,7 @@ type CredentialType string
 type Config struct {
 	CredentialType  CredentialType
 	Endpoint        string
+	EnableTLS       bool
 	AccessKeyID     string
 	AccessKeySecret string
 	Bucket          string
@@ -57,7 +58,7 @@ type Store struct {
 func NewS3(cfg Config) (*Store, error) {
 	client, err := minio.New(cfg.Endpoint, &minio.Options{
 		Creds:  creds(cfg),
-		Secure: false,
+		Secure: cfg.EnableTLS,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Changes proposed

Adding a new `--s3.enable-tls` command line flag to optionally enable SSL connection with the S3 endpoint.
Default value for the new flag is `false` to keep current behaviour. 

I have tested with GCP GCS (`--s3.endpoint=storage.googleapis.com`), that requires a secure connection.

<!-- List all the proposed changes in your PR -->
<!-- Add the screenshots of the changes below if applicable -->

### Screenshots (Optional)

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
