### PR TITLE
fix: verifier srs flags paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,10 @@ lint:
 
 	@golangci-lint run
 
+.PHONY: format
+format:
+	@go fmt ./...
+
 go-gen-mocks:
 	@echo "generating go mocks..."
 	@GO111MODULE=on go generate --run "mockgen*" ./...

--- a/e2e/setup.go
+++ b/e2e/setup.go
@@ -132,7 +132,7 @@ func TestSuiteConfig(t *testing.T, testCfg *Cfg) server.CLIConfig {
 				CacheDir:        "../resources/SRSTables",
 				SRSOrder:        268435456,
 				SRSNumberToLoad: maxBlobLengthBytes / 32,
-				NumWorker:       uint64(runtime.GOMAXPROCS(0)),
+				NumWorker:       uint64(runtime.GOMAXPROCS(0)), // #nosec G115
 			},
 		},
 		MemstoreEnabled: testCfg.UseMemory,

--- a/verify/cli.go
+++ b/verify/cli.go
@@ -86,18 +86,18 @@ func CLIFlags(envPrefix, category string) []cli.Flag {
 			Category: category,
 		},
 		&cli.StringFlag{
-			Name:     G2TauFlagName,
-			Usage:    "Directory path to g2.point.powerOf2 file.",
-			EnvVars:  withEnvPrefix(envPrefix, "TARGET_G2_TAU_PATH"),
+			Name:    G2TauFlagName,
+			Usage:   "Directory path to g2.point.powerOf2 file.",
+			EnvVars: withEnvPrefix(envPrefix, "TARGET_G2_TAU_PATH"),
 			// we use a relative path so that the path works for both the binary and the docker container
 			// aka we assume the binary is run from root dir, and that the resources/ dir is copied into the working dir of the container
 			Value:    "resources/g2.point.powerOf2",
 			Category: category,
 		},
 		&cli.StringFlag{
-			Name:     CachePathFlagName,
-			Usage:    "Directory path to SRS tables for caching.",
-			EnvVars:  withEnvPrefix(envPrefix, "TARGET_CACHE_PATH"),
+			Name:    CachePathFlagName,
+			Usage:   "Directory path to SRS tables for caching.",
+			EnvVars: withEnvPrefix(envPrefix, "TARGET_CACHE_PATH"),
 			// we use a relative path so that the path works for both the binary and the docker container
 			// aka we assume the binary is run from root dir, and that the resources/ dir is copied into the working dir of the container
 			Value:    "resources/SRSTables/",

--- a/verify/cli.go
+++ b/verify/cli.go
@@ -80,23 +80,27 @@ func CLIFlags(envPrefix, category string) []cli.Flag {
 			Name:    G1PathFlagName,
 			Usage:   "Directory path to g1.point file.",
 			EnvVars: withEnvPrefix(envPrefix, "TARGET_KZG_G1_PATH"),
-			// TODO: should use absolute path wrt root directory to prevent future errors
-			//       in case we move this file around
-			Value:    "../resources/g1.point",
+			// we use a relative path so that the path works for both the binary and the docker container
+			// aka we assume the binary is run from root dir, and that the resources/ dir is copied into the working dir of the container
+			Value:    "resources/g1.point",
 			Category: category,
 		},
 		&cli.StringFlag{
 			Name:     G2TauFlagName,
 			Usage:    "Directory path to g2.point.powerOf2 file.",
 			EnvVars:  withEnvPrefix(envPrefix, "TARGET_G2_TAU_PATH"),
-			Value:    "../resources/g2.point.powerOf2",
+			// we use a relative path so that the path works for both the binary and the docker container
+			// aka we assume the binary is run from root dir, and that the resources/ dir is copied into the working dir of the container
+			Value:    "resources/g2.point.powerOf2",
 			Category: category,
 		},
 		&cli.StringFlag{
 			Name:     CachePathFlagName,
 			Usage:    "Directory path to SRS tables for caching.",
 			EnvVars:  withEnvPrefix(envPrefix, "TARGET_CACHE_PATH"),
-			Value:    "../resources/SRSTables/",
+			// we use a relative path so that the path works for both the binary and the docker container
+			// aka we assume the binary is run from root dir, and that the resources/ dir is copied into the working dir of the container
+			Value:    "resources/SRSTables/",
 			Category: category,
 		},
 		// TODO: can we use a genericFlag for this, and automatically parse the string into a uint64?


### PR DESCRIPTION
Made a mistake in https://github.com/Layr-Labs/eigenda-proxy/pull/146

paths should have remained the same given that they are relative to where the binary is run from, not where the go file lives. Fixed and added a comment to that effect.