### PR TITLE
tests: dont wait for finality in e2e tests

### DIFF
--- a/e2e/setup.go
+++ b/e2e/setup.go
@@ -120,6 +120,7 @@ func TestSuiteConfig(t *testing.T, testCfg *Cfg) server.CLIConfig {
 			StatusQueryRetryInterval: pollInterval,
 			DisableTLS:               false,
 			SignerPrivateKeyHex:      pk,
+			WaitForFinalization:      false,
 		},
 		VerifierConfig: verify.Config{
 			VerifyCerts:          false,


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #NNN` to link your PR with the
issue, replacing `#NNN` with the issue number you are fixing -->

## Fixes Issue

<!-- Example: Closes #NNN -->
Fixes #154 

## Changes proposed

<!-- List all the proposed changes in your PR -->
<!-- Add the screenshots of the changes below if applicable -->

not sure if this even works, but trying to not wait for finality to speed up the e2e holesky tests.
There's currently no way to run the tests locally since we don't have the private key we use in the tests stored anywhere accessible (can't read github secrets). Might be nice to put it in our shared password vault.

UPDATE: seems like e2e tests still took 14 mins without waiting for finality... so there's prob something else cause them to be super slow.

### Screenshots (Optional)

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
