### PR TITLE
make backward compatible

### DIFF
--- a/flags/eigendaflags/cli.go
+++ b/flags/eigendaflags/cli.go
@@ -28,7 +28,7 @@ func withFlagPrefix(s string) string {
 }
 
 func withEnvPrefix(envPrefix, s string) []string {
-	return []string{envPrefix + "_EIGENDA_" + s}
+	return []string{envPrefix + "_EIGENDA_CLIENT_" + s, envPrefix + "_" + s}
 }
 
 // CLIFlags ... used for EigenDA client configuration

--- a/store/precomputed_key/s3/cli.go
+++ b/store/precomputed_key/s3/cli.go
@@ -32,7 +32,7 @@ func CLIFlags(envPrefix, category string) []cli.Flag {
 		&cli.StringFlag{
 			Name:     EndpointFlagName,
 			Usage:    "endpoint for S3 storage",
-			EnvVars:  withEnvPrefix(envPrefix, "S3_ENDPOINT"),
+			EnvVars:  withEnvPrefix(envPrefix, "ENDPOINT"),
 			Category: category,
 		},
 		&cli.StringFlag{

--- a/verify/cli.go
+++ b/verify/cli.go
@@ -41,7 +41,7 @@ func withFlagPrefix(s string) string {
 }
 
 func withEnvPrefix(envPrefix, s string) []string {
-	return []string{envPrefix + "_EIGENDA_" + s}
+	return []string{envPrefix + "_EIGENDA_CLIENT_" + s, envPrefix + "_" + s}
 }
 
 // CLIFlags ... used for Verifier configuration


### PR DESCRIPTION
Make env backward compatible.

Method: Adding multiple EnvVars

The urfave doc shows, https://cli.urfave.org/v2/examples/flags/#values-from-the-environment
If EnvVars contains more than one string, the first environment variable that resolves is used.

If this approach looks fine, I will go ahead to change the template env, https://github.com/Layr-Labs/eigenda-proxy/blob/main/.env.example.holesky

Also add a new column to he configuration option in the readme [page](https://github.com/Layr-Labs/eigenda-proxy?tab=readme-ov-file#configuration-options). but @samlaf , do you want to take the rest?

sample

![Screenshot 2024-10-01 at 11 59 10 AM](https://github.com/user-attachments/assets/f1ccc61d-fbdd-4cf0-85c3-10585fb40000)

