### PR TITLE
chore: add deprecated flags to force early crash when used

### DIFF
--- a/flags/eigendaflags/cli.go
+++ b/flags/eigendaflags/cli.go
@@ -27,8 +27,8 @@ func withFlagPrefix(s string) string {
 	return "eigenda." + s
 }
 
-func withEnvPrefix(envPrefix, s string) []string {
-	return []string{envPrefix + "_EIGENDA_" + s}
+func withEnvPrefix(envPrefix, s string) string {
+	return envPrefix + "_EIGENDA_" + s
 }
 
 // CLIFlags ... used for EigenDA client configuration
@@ -37,68 +37,68 @@ func CLIFlags(envPrefix, category string) []cli.Flag {
 		&cli.StringFlag{
 			Name:     DisperserRPCFlagName,
 			Usage:    "RPC endpoint of the EigenDA disperser.",
-			EnvVars:  withEnvPrefix(envPrefix, "DISPERSER_RPC"),
+			EnvVars:  []string{withEnvPrefix(envPrefix, "DISPERSER_RPC")},
 			Category: category,
 		},
 		&cli.DurationFlag{
 			Name:     StatusQueryTimeoutFlagName,
 			Usage:    "Duration to wait for a blob to finalize after being sent for dispersal. Default is 30 minutes.",
 			Value:    30 * time.Minute,
-			EnvVars:  withEnvPrefix(envPrefix, "STATUS_QUERY_TIMEOUT"),
+			EnvVars:  []string{withEnvPrefix(envPrefix, "STATUS_QUERY_TIMEOUT")},
 			Category: category,
 		},
 		&cli.DurationFlag{
 			Name:     StatusQueryRetryIntervalFlagName,
 			Usage:    "Interval between retries when awaiting network blob finalization. Default is 5 seconds.",
 			Value:    5 * time.Second,
-			EnvVars:  withEnvPrefix(envPrefix, "STATUS_QUERY_INTERVAL"),
+			EnvVars:  []string{withEnvPrefix(envPrefix, "STATUS_QUERY_INTERVAL")},
 			Category: category,
 		},
 		&cli.BoolFlag{
 			Name:     DisableTLSFlagName,
 			Usage:    "Disable TLS for gRPC communication with the EigenDA disperser. Default is false.",
 			Value:    false,
-			EnvVars:  withEnvPrefix(envPrefix, "GRPC_DISABLE_TLS"),
+			EnvVars:  []string{withEnvPrefix(envPrefix, "GRPC_DISABLE_TLS")},
 			Category: category,
 		},
 		&cli.DurationFlag{
 			Name:     ResponseTimeoutFlagName,
 			Usage:    "Total time to wait for a response from the EigenDA disperser. Default is 60 seconds.",
 			Value:    60 * time.Second,
-			EnvVars:  withEnvPrefix(envPrefix, "RESPONSE_TIMEOUT"),
+			EnvVars:  []string{withEnvPrefix(envPrefix, "RESPONSE_TIMEOUT")},
 			Category: category,
 		},
 		&cli.UintSliceFlag{
 			Name:     CustomQuorumIDsFlagName,
 			Usage:    "Custom quorum IDs for writing blobs. Should not include default quorums 0 or 1.",
 			Value:    cli.NewUintSlice(),
-			EnvVars:  withEnvPrefix(envPrefix, "CUSTOM_QUORUM_IDS"),
+			EnvVars:  []string{withEnvPrefix(envPrefix, "CUSTOM_QUORUM_IDS")},
 			Category: category,
 		},
 		&cli.StringFlag{
 			Name:     SignerPrivateKeyHexFlagName,
 			Usage:    "Hex-encoded signer private key. This key should not be associated with an Ethereum address holding any funds.",
-			EnvVars:  withEnvPrefix(envPrefix, "SIGNER_PRIVATE_KEY_HEX"),
+			EnvVars:  []string{withEnvPrefix(envPrefix, "SIGNER_PRIVATE_KEY_HEX")},
 			Category: category,
 		},
 		&cli.UintFlag{
 			Name:     PutBlobEncodingVersionFlagName,
 			Usage:    "Blob encoding version to use when writing blobs from the high-level interface.",
-			EnvVars:  withEnvPrefix(envPrefix, "PUT_BLOB_ENCODING_VERSION"),
+			EnvVars:  []string{withEnvPrefix(envPrefix, "PUT_BLOB_ENCODING_VERSION")},
 			Value:    0,
 			Category: category,
 		},
 		&cli.BoolFlag{
 			Name:     DisablePointVerificationModeFlagName,
 			Usage:    "Disable point verification mode. This mode performs IFFT on data before writing and FFT on data after reading. Disabling requires supplying the entire blob for verification against the KZG commitment.",
-			EnvVars:  withEnvPrefix(envPrefix, "DISABLE_POINT_VERIFICATION_MODE"),
+			EnvVars:  []string{withEnvPrefix(envPrefix, "DISABLE_POINT_VERIFICATION_MODE")},
 			Value:    false,
 			Category: category,
 		},
 		&cli.BoolFlag{
 			Name:     WaitForFinalizationFlagName,
 			Usage:    "Wait for blob finalization before returning from PutBlob.",
-			EnvVars:  withEnvPrefix(envPrefix, "WAIT_FOR_FINALIZATION"),
+			EnvVars:  []string{withEnvPrefix(envPrefix, "WAIT_FOR_FINALIZATION")},
 			Value:    false,
 			Category: category,
 		},

--- a/flags/eigendaflags/deprecated.go
+++ b/flags/eigendaflags/deprecated.go
@@ -28,8 +28,8 @@ func withDeprecatedFlagPrefix(s string) string {
 	return "eigenda-" + s
 }
 
-func withDeprecatedEnvPrefix(envPrefix, s string) []string {
-	return []string{envPrefix + "_" + s}
+func withDeprecatedEnvPrefix(envPrefix, s string) string {
+	return envPrefix + "_" + s
 }
 
 // CLIFlags ... used for EigenDA client configuration
@@ -38,7 +38,7 @@ func DeprecatedCLIFlags(envPrefix, category string) []cli.Flag {
 		&cli.StringFlag{
 			Name:     DeprecatedDisperserRPCFlagName,
 			Usage:    "RPC endpoint of the EigenDA disperser.",
-			EnvVars:  withDeprecatedEnvPrefix(envPrefix, "DISPERSER_RPC"),
+			EnvVars:  []string{withDeprecatedEnvPrefix(envPrefix, "DISPERSER_RPC")},
 			Category: category,
 			Action: func(*cli.Context, string) error {
 				return fmt.Errorf("flag --%s (env var %s) is deprecated, use --%s (env var %s) instead",
@@ -50,7 +50,7 @@ func DeprecatedCLIFlags(envPrefix, category string) []cli.Flag {
 			Name:     DeprecatedStatusQueryTimeoutFlagName,
 			Usage:    "Duration to wait for a blob to finalize after being sent for dispersal. Default is 30 minutes.",
 			Value:    30 * time.Minute,
-			EnvVars:  withDeprecatedEnvPrefix(envPrefix, "STATUS_QUERY_TIMEOUT"),
+			EnvVars:  []string{withDeprecatedEnvPrefix(envPrefix, "STATUS_QUERY_TIMEOUT")},
 			Category: category,
 			Action: func(*cli.Context, time.Duration) error {
 				return fmt.Errorf("flag --%s (env var %s) is deprecated, use --%s (env var %s) instead",
@@ -62,7 +62,7 @@ func DeprecatedCLIFlags(envPrefix, category string) []cli.Flag {
 			Name:     DeprecatedStatusQueryRetryIntervalFlagName,
 			Usage:    "Interval between retries when awaiting network blob finalization. Default is 5 seconds.",
 			Value:    5 * time.Second,
-			EnvVars:  withDeprecatedEnvPrefix(envPrefix, "STATUS_QUERY_INTERVAL"),
+			EnvVars:  []string{withDeprecatedEnvPrefix(envPrefix, "STATUS_QUERY_INTERVAL")},
 			Category: category,
 			Action: func(*cli.Context, time.Duration) error {
 				return fmt.Errorf("flag --%s (env var %s) is deprecated, use --%s (env var %s) instead",
@@ -74,7 +74,7 @@ func DeprecatedCLIFlags(envPrefix, category string) []cli.Flag {
 			Name:     DeprecatedDisableTLSFlagName,
 			Usage:    "Disable TLS for gRPC communication with the EigenDA disperser. Default is false.",
 			Value:    false,
-			EnvVars:  withDeprecatedEnvPrefix(envPrefix, "GRPC_DISABLE_TLS"),
+			EnvVars:  []string{withDeprecatedEnvPrefix(envPrefix, "GRPC_DISABLE_TLS")},
 			Category: category,
 			Action: func(*cli.Context, bool) error {
 				return fmt.Errorf("flag --%s (env var %s) is deprecated, use --%s (env var %s) instead",
@@ -86,7 +86,7 @@ func DeprecatedCLIFlags(envPrefix, category string) []cli.Flag {
 			Name:     DeprecatedResponseTimeoutFlagName,
 			Usage:    "Total time to wait for a response from the EigenDA disperser. Default is 60 seconds.",
 			Value:    60 * time.Second,
-			EnvVars:  withDeprecatedEnvPrefix(envPrefix, "RESPONSE_TIMEOUT"),
+			EnvVars:  []string{withDeprecatedEnvPrefix(envPrefix, "RESPONSE_TIMEOUT")},
 			Category: category,
 			Action: func(*cli.Context, time.Duration) error {
 				return fmt.Errorf("flag --%s (env var %s) is deprecated, use --%s (env var %s) instead",
@@ -98,7 +98,7 @@ func DeprecatedCLIFlags(envPrefix, category string) []cli.Flag {
 			Name:     DeprecatedCustomQuorumIDsFlagName,
 			Usage:    "Custom quorum IDs for writing blobs. Should not include default quorums 0 or 1.",
 			Value:    cli.NewUintSlice(),
-			EnvVars:  withDeprecatedEnvPrefix(envPrefix, "CUSTOM_QUORUM_IDS"),
+			EnvVars:  []string{withDeprecatedEnvPrefix(envPrefix, "CUSTOM_QUORUM_IDS")},
 			Category: category,
 			Action: func(*cli.Context, []uint) error {
 				return fmt.Errorf("flag --%s (env var %s) is deprecated, use --%s (env var %s) instead",
@@ -109,7 +109,7 @@ func DeprecatedCLIFlags(envPrefix, category string) []cli.Flag {
 		&cli.StringFlag{
 			Name:     DeprecatedSignerPrivateKeyHexFlagName,
 			Usage:    "Hex-encoded signer private key. This key should not be associated with an Ethereum address holding any funds.",
-			EnvVars:  withDeprecatedEnvPrefix(envPrefix, "SIGNER_PRIVATE_KEY_HEX"),
+			EnvVars:  []string{withDeprecatedEnvPrefix(envPrefix, "SIGNER_PRIVATE_KEY_HEX")},
 			Category: category,
 			Action: func(*cli.Context, string) error {
 				return fmt.Errorf("flag --%s (env var %s) is deprecated, use --%s (env var %s) instead",
@@ -120,7 +120,7 @@ func DeprecatedCLIFlags(envPrefix, category string) []cli.Flag {
 		&cli.UintFlag{
 			Name:     DeprecatedPutBlobEncodingVersionFlagName,
 			Usage:    "Blob encoding version to use when writing blobs from the high-level interface.",
-			EnvVars:  withDeprecatedEnvPrefix(envPrefix, "PUT_BLOB_ENCODING_VERSION"),
+			EnvVars:  []string{withDeprecatedEnvPrefix(envPrefix, "PUT_BLOB_ENCODING_VERSION")},
 			Value:    0,
 			Category: category,
 			Action: func(*cli.Context, uint) error {
@@ -132,7 +132,7 @@ func DeprecatedCLIFlags(envPrefix, category string) []cli.Flag {
 		&cli.BoolFlag{
 			Name:     DeprecatedDisablePointVerificationModeFlagName,
 			Usage:    "Disable point verification mode. This mode performs IFFT on data before writing and FFT on data after reading. Disabling requires supplying the entire blob for verification against the KZG commitment.",
-			EnvVars:  withDeprecatedEnvPrefix(envPrefix, "DISABLE_POINT_VERIFICATION_MODE"),
+			EnvVars:  []string{withDeprecatedEnvPrefix(envPrefix, "DISABLE_POINT_VERIFICATION_MODE")},
 			Value:    false,
 			Category: category,
 			Action: func(*cli.Context, bool) error {

--- a/flags/eigendaflags/deprecated.go
+++ b/flags/eigendaflags/deprecated.go
@@ -1,0 +1,157 @@
+package eigendaflags
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/urfave/cli/v2"
+)
+
+// All of these flags are deprecated and will be removed in release v2.0.0
+// we leave them here with actions that crash the program to ensure they are not used,
+// and to make it easier for users to find the new flags (instead of silently crashing late during execution
+// because some flag's env var was changed but the user forgot to update it)
+var (
+	DeprecatedDisperserRPCFlagName                 = withDeprecatedFlagPrefix("disperser-rpc")
+	DeprecatedStatusQueryRetryIntervalFlagName     = withDeprecatedFlagPrefix("status-query-retry-interval")
+	DeprecatedStatusQueryTimeoutFlagName           = withDeprecatedFlagPrefix("status-query-timeout")
+	DeprecatedDisableTLSFlagName                   = withDeprecatedFlagPrefix("disable-tls")
+	DeprecatedResponseTimeoutFlagName              = withDeprecatedFlagPrefix("response-timeout")
+	DeprecatedCustomQuorumIDsFlagName              = withDeprecatedFlagPrefix("custom-quorum-ids")
+	DeprecatedSignerPrivateKeyHexFlagName          = withDeprecatedFlagPrefix("signer-private-key-hex")
+	DeprecatedPutBlobEncodingVersionFlagName       = withDeprecatedFlagPrefix("put-blob-encoding-version")
+	DeprecatedDisablePointVerificationModeFlagName = withDeprecatedFlagPrefix("disable-point-verification-mode")
+	DeprecatedWaitForFinalizationFlagName          = withDeprecatedFlagPrefix("wait-for-finalization")
+)
+
+func withDeprecatedFlagPrefix(s string) string {
+	return "eigenda-" + s
+}
+
+func withDeprecatedEnvPrefix(envPrefix, s string) []string {
+	return []string{envPrefix + "_" + s}
+}
+
+// CLIFlags ... used for EigenDA client configuration
+func DeprecatedCLIFlags(envPrefix, category string) []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:     DeprecatedDisperserRPCFlagName,
+			Usage:    "RPC endpoint of the EigenDA disperser.",
+			EnvVars:  withDeprecatedEnvPrefix(envPrefix, "DISPERSER_RPC"),
+			Category: category,
+			Action: func(*cli.Context, string) error {
+				return fmt.Errorf("flag --%s (env var %s) is deprecated, use --%s (env var %s) instead",
+					DeprecatedDisperserRPCFlagName, withDeprecatedEnvPrefix(envPrefix, "DISPERSER_RPC"),
+					DisperserRPCFlagName, withEnvPrefix(envPrefix, "DISPERSER_RPC"))
+			},
+		},
+		&cli.DurationFlag{
+			Name:     DeprecatedStatusQueryTimeoutFlagName,
+			Usage:    "Duration to wait for a blob to finalize after being sent for dispersal. Default is 30 minutes.",
+			Value:    30 * time.Minute,
+			EnvVars:  withDeprecatedEnvPrefix(envPrefix, "STATUS_QUERY_TIMEOUT"),
+			Category: category,
+			Action: func(*cli.Context, time.Duration) error {
+				return fmt.Errorf("flag --%s (env var %s) is deprecated, use --%s (env var %s) instead",
+					DeprecatedStatusQueryTimeoutFlagName, withDeprecatedEnvPrefix(envPrefix, "STATUS_QUERY_TIMEOUT"),
+					StatusQueryTimeoutFlagName, withEnvPrefix(envPrefix, "STATUS_QUERY_TIMEOUT"))
+			},
+		},
+		&cli.DurationFlag{
+			Name:     DeprecatedStatusQueryRetryIntervalFlagName,
+			Usage:    "Interval between retries when awaiting network blob finalization. Default is 5 seconds.",
+			Value:    5 * time.Second,
+			EnvVars:  withDeprecatedEnvPrefix(envPrefix, "STATUS_QUERY_INTERVAL"),
+			Category: category,
+			Action: func(*cli.Context, time.Duration) error {
+				return fmt.Errorf("flag --%s (env var %s) is deprecated, use --%s (env var %s) instead",
+					DeprecatedStatusQueryRetryIntervalFlagName, withDeprecatedEnvPrefix(envPrefix, "STATUS_QUERY_INTERVAL"),
+					StatusQueryRetryIntervalFlagName, withEnvPrefix(envPrefix, "STATUS_QUERY_INTERVAL"))
+			},
+		},
+		&cli.BoolFlag{
+			Name:     DeprecatedDisableTLSFlagName,
+			Usage:    "Disable TLS for gRPC communication with the EigenDA disperser. Default is false.",
+			Value:    false,
+			EnvVars:  withDeprecatedEnvPrefix(envPrefix, "GRPC_DISABLE_TLS"),
+			Category: category,
+			Action: func(*cli.Context, bool) error {
+				return fmt.Errorf("flag --%s (env var %s) is deprecated, use --%s (env var %s) instead",
+					DeprecatedDisableTLSFlagName, withDeprecatedEnvPrefix(envPrefix, "GRPC_DISABLE_TLS"),
+					DisableTLSFlagName, withEnvPrefix(envPrefix, "GRPC_DISABLE_TLS"))
+			},
+		},
+		&cli.DurationFlag{
+			Name:     DeprecatedResponseTimeoutFlagName,
+			Usage:    "Total time to wait for a response from the EigenDA disperser. Default is 60 seconds.",
+			Value:    60 * time.Second,
+			EnvVars:  withDeprecatedEnvPrefix(envPrefix, "RESPONSE_TIMEOUT"),
+			Category: category,
+			Action: func(*cli.Context, time.Duration) error {
+				return fmt.Errorf("flag --%s (env var %s) is deprecated, use --%s (env var %s) instead",
+					DeprecatedResponseTimeoutFlagName, withDeprecatedEnvPrefix(envPrefix, "RESPONSE_TIMEOUT"),
+					ResponseTimeoutFlagName, withEnvPrefix(envPrefix, "RESPONSE_TIMEOUT"))
+			},
+		},
+		&cli.UintSliceFlag{
+			Name:     DeprecatedCustomQuorumIDsFlagName,
+			Usage:    "Custom quorum IDs for writing blobs. Should not include default quorums 0 or 1.",
+			Value:    cli.NewUintSlice(),
+			EnvVars:  withDeprecatedEnvPrefix(envPrefix, "CUSTOM_QUORUM_IDS"),
+			Category: category,
+			Action: func(*cli.Context, []uint) error {
+				return fmt.Errorf("flag --%s (env var %s) is deprecated, use --%s (env var %s) instead",
+					DeprecatedCustomQuorumIDsFlagName, withDeprecatedEnvPrefix(envPrefix, "CUSTOM_QUORUM_IDS"),
+					CustomQuorumIDsFlagName, withEnvPrefix(envPrefix, "CUSTOM_QUORUM_IDS"))
+			},
+		},
+		&cli.StringFlag{
+			Name:     DeprecatedSignerPrivateKeyHexFlagName,
+			Usage:    "Hex-encoded signer private key. This key should not be associated with an Ethereum address holding any funds.",
+			EnvVars:  withDeprecatedEnvPrefix(envPrefix, "SIGNER_PRIVATE_KEY_HEX"),
+			Category: category,
+			Action: func(*cli.Context, string) error {
+				return fmt.Errorf("flag --%s (env var %s) is deprecated, use --%s (env var %s) instead",
+					DeprecatedSignerPrivateKeyHexFlagName, withDeprecatedEnvPrefix(envPrefix, "SIGNER_PRIVATE_KEY_HEX"),
+					SignerPrivateKeyHexFlagName, withEnvPrefix(envPrefix, "SIGNER_PRIVATE_KEY_HEX"))
+			},
+		},
+		&cli.UintFlag{
+			Name:     DeprecatedPutBlobEncodingVersionFlagName,
+			Usage:    "Blob encoding version to use when writing blobs from the high-level interface.",
+			EnvVars:  withDeprecatedEnvPrefix(envPrefix, "PUT_BLOB_ENCODING_VERSION"),
+			Value:    0,
+			Category: category,
+			Action: func(*cli.Context, uint) error {
+				return fmt.Errorf("flag --%s (env var %s) is deprecated, use --%s (env var %s) instead",
+					DeprecatedPutBlobEncodingVersionFlagName, withDeprecatedEnvPrefix(envPrefix, "PUT_BLOB_ENCODING_VERSION"),
+					PutBlobEncodingVersionFlagName, withEnvPrefix(envPrefix, "PUT_BLOB_ENCODING_VERSION"))
+			},
+		},
+		&cli.BoolFlag{
+			Name:     DeprecatedDisablePointVerificationModeFlagName,
+			Usage:    "Disable point verification mode. This mode performs IFFT on data before writing and FFT on data after reading. Disabling requires supplying the entire blob for verification against the KZG commitment.",
+			EnvVars:  withDeprecatedEnvPrefix(envPrefix, "DISABLE_POINT_VERIFICATION_MODE"),
+			Value:    false,
+			Category: category,
+			Action: func(*cli.Context, bool) error {
+				return fmt.Errorf("flag --%s (env var %s) is deprecated, use --%s (env var %s) instead",
+					DeprecatedDisablePointVerificationModeFlagName, withDeprecatedEnvPrefix(envPrefix, "DISABLE_POINT_VERIFICATION_MODE"),
+					DisablePointVerificationModeFlagName, withEnvPrefix(envPrefix, "DISABLE_POINT_VERIFICATION_MODE"))
+			},
+		},
+		&cli.BoolFlag{
+			Name:     DeprecatedWaitForFinalizationFlagName,
+			Usage:    "Wait for blob finalization before returning from PutBlob.",
+			EnvVars:  withDeprecatedEnvPrefix(envPrefix, "WAIT_FOR_FINALIZATION"),
+			Value:    false,
+			Category: category,
+			Action: func(*cli.Context, bool) error {
+				return fmt.Errorf("flag --%s (env var %s) is deprecated, use --%s (env var %s) instead",
+					DeprecatedWaitForFinalizationFlagName, withDeprecatedEnvPrefix(envPrefix, "WAIT_FOR_FINALIZATION"),
+					WaitForFinalizationFlagName, withEnvPrefix(envPrefix, "WAIT_FOR_FINALIZATION"))
+			},
+		},
+	}
+}

--- a/flags/eigendaflags/deprecated.go
+++ b/flags/eigendaflags/deprecated.go
@@ -141,17 +141,5 @@ func DeprecatedCLIFlags(envPrefix, category string) []cli.Flag {
 					DisablePointVerificationModeFlagName, withEnvPrefix(envPrefix, "DISABLE_POINT_VERIFICATION_MODE"))
 			},
 		},
-		&cli.BoolFlag{
-			Name:     DeprecatedWaitForFinalizationFlagName,
-			Usage:    "Wait for blob finalization before returning from PutBlob.",
-			EnvVars:  withDeprecatedEnvPrefix(envPrefix, "WAIT_FOR_FINALIZATION"),
-			Value:    false,
-			Category: category,
-			Action: func(*cli.Context, bool) error {
-				return fmt.Errorf("flag --%s (env var %s) is deprecated, use --%s (env var %s) instead",
-					DeprecatedWaitForFinalizationFlagName, withDeprecatedEnvPrefix(envPrefix, "WAIT_FOR_FINALIZATION"),
-					WaitForFinalizationFlagName, withEnvPrefix(envPrefix, "WAIT_FOR_FINALIZATION"))
-			},
-		},
 	}
 }

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -14,12 +14,13 @@ import (
 )
 
 const (
-	EigenDAClientCategory     = "EigenDA Client"
-	EigenDADeprecatedCategory = "DEPRECATED EIGENDA CLIENT FLAGS -- THESE WILL BE REMOVED IN V2.0.0"
-	MemstoreFlagsCategory     = "Memstore (for testing purposes - replaces EigenDA backend)"
-	RedisCategory             = "Redis Cache/Fallback"
-	S3Category                = "S3 Cache/Fallback"
-	VerifierCategory          = "KZG and Cert Verifier"
+	EigenDAClientCategory      = "EigenDA Client"
+	EigenDADeprecatedCategory  = "DEPRECATED EIGENDA CLIENT FLAGS -- THESE WILL BE REMOVED IN V2.0.0"
+	MemstoreFlagsCategory      = "Memstore (for testing purposes - replaces EigenDA backend)"
+	RedisCategory              = "Redis Cache/Fallback"
+	S3Category                 = "S3 Cache/Fallback"
+	VerifierCategory           = "KZG and Cert Verifier"
+	VerifierDeprecatedCategory = "DEPRECATED VERIFIER FLAGS -- THESE WILL BE REMOVED IN V2.0.0"
 )
 
 const (
@@ -82,4 +83,5 @@ func init() {
 	Flags = append(Flags, s3.CLIFlags(EnvVarPrefix, S3Category)...)
 	Flags = append(Flags, memstore.CLIFlags(EnvVarPrefix, MemstoreFlagsCategory)...)
 	Flags = append(Flags, verify.CLIFlags(EnvVarPrefix, VerifierCategory)...)
+	Flags = append(Flags, verify.DeprecatedCLIFlags(EnvVarPrefix, VerifierDeprecatedCategory)...)
 }

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -16,7 +16,7 @@ import (
 const (
 	EigenDAClientCategory     = "EigenDA Client"
 	EigenDADeprecatedCategory = "DEPRECATED EIGENDA CLIENT FLAGS -- THESE WILL BE REMOVED IN V2.0.0"
-	MemstoreFlagsCategory     = "Memstore (replaces EigenDA when enabled)"
+	MemstoreFlagsCategory     = "Memstore (for testing purposes - replaces EigenDA backend)"
 	RedisCategory             = "Redis Cache/Fallback"
 	S3Category                = "S3 Cache/Fallback"
 	VerifierCategory          = "KZG and Cert Verifier"

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -14,11 +14,12 @@ import (
 )
 
 const (
-	EigenDAClientCategory = "EigenDA Client"
-	MemstoreFlagsCategory = "Memstore (replaces EigenDA when enabled)"
-	RedisCategory         = "Redis Cache/Fallback"
-	S3Category            = "S3 Cache/Fallback"
-	VerifierCategory      = "KZG and Cert Verifier"
+	EigenDAClientCategory     = "EigenDA Client"
+	EigenDADeprecatedCategory = "DEPRECATED EIGENDA CLIENT FLAGS -- THESE WILL BE REMOVED IN V2.0.0"
+	MemstoreFlagsCategory     = "Memstore (replaces EigenDA when enabled)"
+	RedisCategory             = "Redis Cache/Fallback"
+	S3Category                = "S3 Cache/Fallback"
+	VerifierCategory          = "KZG and Cert Verifier"
 )
 
 const (
@@ -76,6 +77,7 @@ func init() {
 	Flags = append(Flags, oplog.CLIFlags(EnvVarPrefix)...)
 	Flags = append(Flags, opmetrics.CLIFlags(EnvVarPrefix)...)
 	Flags = append(Flags, eigendaflags.CLIFlags(EnvVarPrefix, EigenDAClientCategory)...)
+	Flags = append(Flags, eigendaflags.DeprecatedCLIFlags(EnvVarPrefix, EigenDADeprecatedCategory)...)
 	Flags = append(Flags, redis.CLIFlags(EnvVarPrefix, RedisCategory)...)
 	Flags = append(Flags, s3.CLIFlags(EnvVarPrefix, S3Category)...)
 	Flags = append(Flags, memstore.CLIFlags(EnvVarPrefix, MemstoreFlagsCategory)...)

--- a/store/generated_key/memstore/cli.go
+++ b/store/generated_key/memstore/cli.go
@@ -44,7 +44,7 @@ func CLIFlags(envPrefix, category string) []cli.Flag {
 					return fmt.Errorf("env var %s is deprecated for flag %s, use %s instead",
 						withDeprecatedEnvPrefix(envPrefix, "ENABLED"),
 						EnabledFlagName,
-						withEnvPrefix(envPrefix, "ENABLED")[0])
+						withEnvPrefix(envPrefix, "ENABLED"))
 				}
 				return nil
 			},
@@ -60,7 +60,7 @@ func CLIFlags(envPrefix, category string) []cli.Flag {
 					return fmt.Errorf("env var %s is deprecated for flag %s, use %s instead",
 						withDeprecatedEnvPrefix(envPrefix, "EXPIRATION"),
 						ExpirationFlagName,
-						withEnvPrefix(envPrefix, "EXPIRATION")[0])
+						withEnvPrefix(envPrefix, "EXPIRATION"))
 				}
 				return nil
 			},

--- a/store/generated_key/memstore/cli.go
+++ b/store/generated_key/memstore/cli.go
@@ -20,10 +20,8 @@ func withFlagPrefix(s string) string {
 	return "memstore." + s
 }
 
-func withEnvPrefix(envPrefix, s string) []string {
-	return []string{
-		envPrefix + "_MEMSTORE_" + s,
-	}
+func withEnvPrefix(envPrefix, s string) string {
+	return envPrefix + "_MEMSTORE_" + s
 }
 
 // if these deprecated env vars are used, we force the user to update their config
@@ -39,7 +37,7 @@ func CLIFlags(envPrefix, category string) []cli.Flag {
 		&cli.BoolFlag{
 			Name:     EnabledFlagName,
 			Usage:    "Whether to use memstore for DA logic.",
-			EnvVars:  append(withEnvPrefix(envPrefix, "ENABLED"), withDeprecatedEnvPrefix(envPrefix, "ENABLED")),
+			EnvVars:  []string{withEnvPrefix(envPrefix, "ENABLED"), withDeprecatedEnvPrefix(envPrefix, "ENABLED")},
 			Category: category,
 			Action: func(_ *cli.Context, _ bool) error {
 				if _, ok := os.LookupEnv(withDeprecatedEnvPrefix(envPrefix, "ENABLED")); ok {
@@ -55,7 +53,7 @@ func CLIFlags(envPrefix, category string) []cli.Flag {
 			Name:     ExpirationFlagName,
 			Usage:    "Duration that a memstore blob/commitment pair is allowed to live.",
 			Value:    25 * time.Minute,
-			EnvVars:  append(withEnvPrefix(envPrefix, "EXPIRATION"), withDeprecatedEnvPrefix(envPrefix, "EXPIRATION")),
+			EnvVars:  []string{withEnvPrefix(envPrefix, "EXPIRATION"), withDeprecatedEnvPrefix(envPrefix, "EXPIRATION")},
 			Category: category,
 			Action: func(_ *cli.Context, _ time.Duration) error {
 				if _, ok := os.LookupEnv(withDeprecatedEnvPrefix(envPrefix, "EXPIRATION")); ok {
@@ -71,14 +69,14 @@ func CLIFlags(envPrefix, category string) []cli.Flag {
 			Name:     PutLatencyFlagName,
 			Usage:    "Artificial latency added for memstore backend to mimic EigenDA's dispersal latency.",
 			Value:    0,
-			EnvVars:  withEnvPrefix(envPrefix, "PUT_LATENCY"),
+			EnvVars:  []string{withEnvPrefix(envPrefix, "PUT_LATENCY")},
 			Category: category,
 		},
 		&cli.DurationFlag{
 			Name:     GetLatencyFlagName,
 			Usage:    "Artificial latency added for memstore backend to mimic EigenDA's retrieval latency.",
 			Value:    0,
-			EnvVars:  withEnvPrefix(envPrefix, "GET_LATENCY"),
+			EnvVars:  []string{withEnvPrefix(envPrefix, "GET_LATENCY")},
 			Category: category,
 		},
 	}

--- a/store/generated_key/memstore/cli.go
+++ b/store/generated_key/memstore/cli.go
@@ -28,7 +28,7 @@ func withEnvPrefix(envPrefix, s string) []string {
 
 // if these deprecated env vars are used, we force the user to update their config
 // in the flags' actions
-func withDeprecatedEnvPrefix(envPrefix, s string) string {
+func withDeprecatedEnvPrefix(_, s string) string {
 	return "MEMSTORE_" + s
 }
 

--- a/verify/cli.go
+++ b/verify/cli.go
@@ -40,8 +40,8 @@ func withFlagPrefix(s string) string {
 	return "eigenda." + s
 }
 
-func withEnvPrefix(envPrefix, s string) []string {
-	return []string{envPrefix + "_EIGENDA_" + s}
+func withEnvPrefix(envPrefix, s string) string {
+	return envPrefix + "_EIGENDA_" + s
 }
 
 // CLIFlags ... used for Verifier configuration
@@ -51,26 +51,26 @@ func CLIFlags(envPrefix, category string) []cli.Flag {
 		&cli.BoolFlag{
 			Name:     CertVerificationDisabledFlagName,
 			Usage:    "Whether to verify certificates received from EigenDA disperser.",
-			EnvVars:  withEnvPrefix(envPrefix, "CERT_VERIFICATION_DISABLED"),
+			EnvVars:  []string{withEnvPrefix(envPrefix, "CERT_VERIFICATION_DISABLED")},
 			Value:    false,
 			Category: category,
 		},
 		&cli.StringFlag{
 			Name:     EthRPCFlagName,
 			Usage:    "JSON RPC node endpoint for the Ethereum network used for finalizing DA blobs. See available list here: https://docs.eigenlayer.xyz/eigenda/networks/",
-			EnvVars:  withEnvPrefix(envPrefix, "ETH_RPC"),
+			EnvVars:  []string{withEnvPrefix(envPrefix, "ETH_RPC")},
 			Category: category,
 		},
 		&cli.StringFlag{
 			Name:     SvcManagerAddrFlagName,
 			Usage:    "The deployed EigenDA service manager address. The list can be found here: https://github.com/Layr-Labs/eigenlayer-middleware/?tab=readme-ov-file#current-mainnet-deployment",
-			EnvVars:  withEnvPrefix(envPrefix, "SERVICE_MANAGER_ADDR"),
+			EnvVars:  []string{withEnvPrefix(envPrefix, "SERVICE_MANAGER_ADDR")},
 			Category: category,
 		},
 		&cli.Uint64Flag{
 			Name:     EthConfirmationDepthFlagName,
 			Usage:    "The number of Ethereum blocks to wait before considering a submitted blob's DA batch submission confirmed. `0` means wait for inclusion only.",
-			EnvVars:  withEnvPrefix(envPrefix, "ETH_CONFIRMATION_DEPTH"),
+			EnvVars:  []string{withEnvPrefix(envPrefix, "ETH_CONFIRMATION_DEPTH")},
 			Value:    0,
 			Category: category,
 		},
@@ -78,7 +78,7 @@ func CLIFlags(envPrefix, category string) []cli.Flag {
 		&cli.StringFlag{
 			Name:    G1PathFlagName,
 			Usage:   "Directory path to g1.point file.",
-			EnvVars: withEnvPrefix(envPrefix, "TARGET_KZG_G1_PATH"),
+			EnvVars: []string{withEnvPrefix(envPrefix, "TARGET_KZG_G1_PATH")},
 			// we use a relative path so that the path works for both the binary and the docker container
 			// aka we assume the binary is run from root dir, and that the resources/ dir is copied into the working dir of the container
 			Value:    "resources/g1.point",
@@ -87,7 +87,7 @@ func CLIFlags(envPrefix, category string) []cli.Flag {
 		&cli.StringFlag{
 			Name:    G2PowerOf2PathFlagName,
 			Usage:   "Directory path to g2.point.powerOf2 file. This resource is not currently used, but needed because of the shared eigenda KZG library that we use. We will eventually fix this.",
-			EnvVars: withEnvPrefix(envPrefix, "TARGET_KZG_G2_POWER_OF_2_PATH"),
+			EnvVars: []string{withEnvPrefix(envPrefix, "TARGET_KZG_G2_POWER_OF_2_PATH")},
 			// we use a relative path so that the path works for both the binary and the docker container
 			// aka we assume the binary is run from root dir, and that the resources/ dir is copied into the working dir of the container
 			Value:    "resources/g2.point.powerOf2",
@@ -96,7 +96,7 @@ func CLIFlags(envPrefix, category string) []cli.Flag {
 		&cli.StringFlag{
 			Name:    CachePathFlagName,
 			Usage:   "Directory path to SRS tables for caching. This resource is not currently used, but needed because of the shared eigenda KZG library that we use. We will eventually fix this.",
-			EnvVars: withEnvPrefix(envPrefix, "TARGET_CACHE_PATH"),
+			EnvVars: []string{withEnvPrefix(envPrefix, "TARGET_CACHE_PATH")},
 			// we use a relative path so that the path works for both the binary and the docker container
 			// aka we assume the binary is run from root dir, and that the resources/ dir is copied into the working dir of the container
 			Value:    "resources/SRSTables/",
@@ -106,7 +106,7 @@ func CLIFlags(envPrefix, category string) []cli.Flag {
 		&cli.StringFlag{
 			Name:    MaxBlobLengthFlagName,
 			Usage:   "Maximum blob length to be written or read from EigenDA. Determines the number of SRS points loaded into memory for KZG commitments. Example units: '30MiB', '4Kb', '30MB'. Maximum size slightly exceeds 1GB.",
-			EnvVars: withEnvPrefix(envPrefix, "MAX_BLOB_LENGTH"),
+			EnvVars: []string{withEnvPrefix(envPrefix, "MAX_BLOB_LENGTH")},
 			Value:   "16MiB",
 			// set to true to force action to run on the default Value
 			// see https://github.com/urfave/cli/issues/1973

--- a/verify/deprecated_flags.go
+++ b/verify/deprecated_flags.go
@@ -26,8 +26,8 @@ func withDeprecatedFlagPrefix(s string) string {
 	return "eigenda-" + s
 }
 
-func withDeprecatedEnvPrefix(envPrefix, s string) []string {
-	return []string{envPrefix + "_" + s}
+func withDeprecatedEnvPrefix(envPrefix, s string) string {
+	return envPrefix + "_" + s
 }
 
 // CLIFlags ... used for Verifier configuration
@@ -37,7 +37,7 @@ func DeprecatedCLIFlags(envPrefix, category string) []cli.Flag {
 		&cli.StringFlag{
 			Name:    DeprecatedEthRPCFlagName,
 			Usage:   "JSON RPC node endpoint for the Ethereum network used for finalizing DA blobs. See available list here: https://docs.eigenlayer.xyz/eigenda/networks/",
-			EnvVars: withDeprecatedEnvPrefix(envPrefix, "ETH_RPC"),
+			EnvVars: []string{withDeprecatedEnvPrefix(envPrefix, "ETH_RPC")},
 			Action: func(_ *cli.Context, _ string) error {
 				return fmt.Errorf("flag --%s (env var %s) is deprecated, use --%s (env var %s) instead",
 					DeprecatedEthRPCFlagName, withDeprecatedEnvPrefix(envPrefix, "ETH_RPC"),
@@ -48,7 +48,7 @@ func DeprecatedCLIFlags(envPrefix, category string) []cli.Flag {
 		&cli.StringFlag{
 			Name:    DeprecatedSvcManagerAddrFlagName,
 			Usage:   "The deployed EigenDA service manager address. The list can be found here: https://github.com/Layr-Labs/eigenlayer-middleware/?tab=readme-ov-file#current-mainnet-deployment",
-			EnvVars: withDeprecatedEnvPrefix(envPrefix, "SERVICE_MANAGER_ADDR"),
+			EnvVars: []string{withDeprecatedEnvPrefix(envPrefix, "SERVICE_MANAGER_ADDR")},
 			Action: func(_ *cli.Context, _ string) error {
 				return fmt.Errorf("flag --%s (env var %s) is deprecated, use --%s (env var %s) instead",
 					DeprecatedSvcManagerAddrFlagName, withDeprecatedEnvPrefix(envPrefix, "SERVICE_MANAGER_ADDR"),
@@ -59,7 +59,7 @@ func DeprecatedCLIFlags(envPrefix, category string) []cli.Flag {
 		&cli.Uint64Flag{
 			Name:    DeprecatedEthConfirmationDepthFlagName,
 			Usage:   "The number of Ethereum blocks to wait before considering a submitted blob's DA batch submission confirmed. `0` means wait for inclusion only.",
-			EnvVars: withDeprecatedEnvPrefix(envPrefix, "ETH_CONFIRMATION_DEPTH"),
+			EnvVars: []string{withDeprecatedEnvPrefix(envPrefix, "ETH_CONFIRMATION_DEPTH")},
 			Value:   0,
 			Action: func(_ *cli.Context, _ uint64) error {
 				return fmt.Errorf("flag --%s (env var %s) is deprecated, use --%s (env var %s) instead",
@@ -72,7 +72,7 @@ func DeprecatedCLIFlags(envPrefix, category string) []cli.Flag {
 		&cli.StringFlag{
 			Name:    DeprecatedG1PathFlagName,
 			Usage:   "Directory path to g1.point file.",
-			EnvVars: withDeprecatedEnvPrefix(envPrefix, "TARGET_KZG_G1_PATH"),
+			EnvVars: []string{withDeprecatedEnvPrefix(envPrefix, "TARGET_KZG_G1_PATH")},
 			// we use a relative path so that the path works for both the binary and the docker container
 			// aka we assume the binary is run from root dir, and that the resources/ dir is copied into the working dir of the container
 			Value: "resources/g1.point",
@@ -86,7 +86,7 @@ func DeprecatedCLIFlags(envPrefix, category string) []cli.Flag {
 		&cli.StringFlag{
 			Name:    DeprecatedG2TauFlagName,
 			Usage:   "Directory path to g2.point.powerOf2 file.",
-			EnvVars: withDeprecatedEnvPrefix(envPrefix, "TARGET_G2_TAU_PATH"),
+			EnvVars: []string{withDeprecatedEnvPrefix(envPrefix, "TARGET_G2_TAU_PATH")},
 			// we use a relative path so that the path works for both the binary and the docker container
 			// aka we assume the binary is run from root dir, and that the resources/ dir is copied into the working dir of the container
 			Value: "resources/g2.point.powerOf2",
@@ -100,7 +100,7 @@ func DeprecatedCLIFlags(envPrefix, category string) []cli.Flag {
 		&cli.StringFlag{
 			Name:    DeprecatedCachePathFlagName,
 			Usage:   "Directory path to SRS tables for caching.",
-			EnvVars: withDeprecatedEnvPrefix(envPrefix, "TARGET_CACHE_PATH"),
+			EnvVars: []string{withDeprecatedEnvPrefix(envPrefix, "TARGET_CACHE_PATH")},
 			// we use a relative path so that the path works for both the binary and the docker container
 			// aka we assume the binary is run from root dir, and that the resources/ dir is copied into the working dir of the container
 			Value: "resources/SRSTables/",
@@ -115,7 +115,7 @@ func DeprecatedCLIFlags(envPrefix, category string) []cli.Flag {
 		&cli.StringFlag{
 			Name:    DeprecatedMaxBlobLengthFlagName,
 			Usage:   "Maximum blob length to be written or read from EigenDA. Determines the number of SRS points loaded into memory for KZG commitments. Example units: '30MiB', '4Kb', '30MB'. Maximum size slightly exceeds 1GB.",
-			EnvVars: withDeprecatedEnvPrefix(envPrefix, "MAX_BLOB_LENGTH"),
+			EnvVars: []string{withDeprecatedEnvPrefix(envPrefix, "MAX_BLOB_LENGTH")},
 			Value:   "16MiB",
 			Action: func(_ *cli.Context, _ string) error {
 				return fmt.Errorf("flag --%s (env var %s) is deprecated, use --%s (env var %s) instead",

--- a/verify/deprecated_flags.go
+++ b/verify/deprecated_flags.go
@@ -1,0 +1,130 @@
+package verify
+
+import (
+	"fmt"
+
+	"github.com/urfave/cli/v2"
+)
+
+// TODO: we should also upstream these deprecated flags into the eigenda client
+// if we upstream the changes before removing the deprecated flags
+var (
+	// cert verification flags
+	DeprecatedCertVerificationEnabledFlagName = withDeprecatedFlagPrefix("cert-verification-enabled")
+	DeprecatedEthRPCFlagName                  = withDeprecatedFlagPrefix("eth-rpc")
+	DeprecatedSvcManagerAddrFlagName          = withDeprecatedFlagPrefix("svc-manager-addr")
+	DeprecatedEthConfirmationDepthFlagName    = withDeprecatedFlagPrefix("eth-confirmation-depth")
+
+	// kzg flags
+	DeprecatedG1PathFlagName        = withDeprecatedFlagPrefix("g1-path")
+	DeprecatedG2TauFlagName         = withDeprecatedFlagPrefix("g2-tau-path")
+	DeprecatedCachePathFlagName     = withDeprecatedFlagPrefix("cache-path")
+	DeprecatedMaxBlobLengthFlagName = withDeprecatedFlagPrefix("max-blob-length")
+)
+
+func withDeprecatedFlagPrefix(s string) string {
+	return "eigenda-" + s
+}
+
+func withDeprecatedEnvPrefix(envPrefix, s string) []string {
+	return []string{envPrefix + "_" + s}
+}
+
+// CLIFlags ... used for Verifier configuration
+// category is used to group the flags in the help output (see https://cli.urfave.org/v2/examples/flags/#grouping)
+func DeprecatedCLIFlags(envPrefix, category string) []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:    DeprecatedEthRPCFlagName,
+			Usage:   "JSON RPC node endpoint for the Ethereum network used for finalizing DA blobs. See available list here: https://docs.eigenlayer.xyz/eigenda/networks/",
+			EnvVars: withDeprecatedEnvPrefix(envPrefix, "ETH_RPC"),
+			Action: func(_ *cli.Context, _ string) error {
+				return fmt.Errorf("flag --%s (env var %s) is deprecated, use --%s (env var %s) instead",
+					DeprecatedEthRPCFlagName, withDeprecatedEnvPrefix(envPrefix, "ETH_RPC"),
+					EthRPCFlagName, withEnvPrefix(envPrefix, "ETH_RPC"))
+			},
+			Category: category,
+		},
+		&cli.StringFlag{
+			Name:    DeprecatedSvcManagerAddrFlagName,
+			Usage:   "The deployed EigenDA service manager address. The list can be found here: https://github.com/Layr-Labs/eigenlayer-middleware/?tab=readme-ov-file#current-mainnet-deployment",
+			EnvVars: withDeprecatedEnvPrefix(envPrefix, "SERVICE_MANAGER_ADDR"),
+			Action: func(_ *cli.Context, _ string) error {
+				return fmt.Errorf("flag --%s (env var %s) is deprecated, use --%s (env var %s) instead",
+					DeprecatedSvcManagerAddrFlagName, withDeprecatedEnvPrefix(envPrefix, "SERVICE_MANAGER_ADDR"),
+					SvcManagerAddrFlagName, withEnvPrefix(envPrefix, "SERVICE_MANAGER_ADDR"))
+			},
+			Category: category,
+		},
+		&cli.Uint64Flag{
+			Name:    DeprecatedEthConfirmationDepthFlagName,
+			Usage:   "The number of Ethereum blocks to wait before considering a submitted blob's DA batch submission confirmed. `0` means wait for inclusion only.",
+			EnvVars: withDeprecatedEnvPrefix(envPrefix, "ETH_CONFIRMATION_DEPTH"),
+			Value:   0,
+			Action: func(_ *cli.Context, _ uint64) error {
+				return fmt.Errorf("flag --%s (env var %s) is deprecated, use --%s (env var %s) instead",
+					DeprecatedEthConfirmationDepthFlagName, withDeprecatedEnvPrefix(envPrefix, "ETH_CONFIRMATION_DEPTH"),
+					EthConfirmationDepthFlagName, withEnvPrefix(envPrefix, "ETH_CONFIRMATION_DEPTH"))
+			},
+			Category: category,
+		},
+		// kzg flags
+		&cli.StringFlag{
+			Name:    DeprecatedG1PathFlagName,
+			Usage:   "Directory path to g1.point file.",
+			EnvVars: withDeprecatedEnvPrefix(envPrefix, "TARGET_KZG_G1_PATH"),
+			// we use a relative path so that the path works for both the binary and the docker container
+			// aka we assume the binary is run from root dir, and that the resources/ dir is copied into the working dir of the container
+			Value: "resources/g1.point",
+			Action: func(_ *cli.Context, _ string) error {
+				return fmt.Errorf("flag --%s (env var %s) is deprecated, use --%s (env var %s) instead",
+					DeprecatedG1PathFlagName, withDeprecatedEnvPrefix(envPrefix, "TARGET_KZG_G1_PATH"),
+					G1PathFlagName, withEnvPrefix(envPrefix, "TARGET_KZG_G1_PATH"))
+			},
+			Category: category,
+		},
+		&cli.StringFlag{
+			Name:    DeprecatedG2TauFlagName,
+			Usage:   "Directory path to g2.point.powerOf2 file.",
+			EnvVars: withDeprecatedEnvPrefix(envPrefix, "TARGET_G2_TAU_PATH"),
+			// we use a relative path so that the path works for both the binary and the docker container
+			// aka we assume the binary is run from root dir, and that the resources/ dir is copied into the working dir of the container
+			Value: "resources/g2.point.powerOf2",
+			Action: func(_ *cli.Context, _ string) error {
+				return fmt.Errorf("flag --%s (env var %s) is deprecated, use --%s (env var %s) instead",
+					DeprecatedG2TauFlagName, withDeprecatedEnvPrefix(envPrefix, "TARGET_G2_TAU_PATH"),
+					G2PowerOf2PathFlagName, withEnvPrefix(envPrefix, "TARGET_KZG_G2_POWER_OF_2_PATH"))
+			},
+			Category: category,
+		},
+		&cli.StringFlag{
+			Name:    DeprecatedCachePathFlagName,
+			Usage:   "Directory path to SRS tables for caching.",
+			EnvVars: withDeprecatedEnvPrefix(envPrefix, "TARGET_CACHE_PATH"),
+			// we use a relative path so that the path works for both the binary and the docker container
+			// aka we assume the binary is run from root dir, and that the resources/ dir is copied into the working dir of the container
+			Value: "resources/SRSTables/",
+			Action: func(_ *cli.Context, _ string) error {
+				return fmt.Errorf("flag --%s (env var %s) is deprecated, use --%s (env var %s) instead",
+					DeprecatedCachePathFlagName, withDeprecatedEnvPrefix(envPrefix, "TARGET_CACHE_PATH"),
+					CachePathFlagName, withEnvPrefix(envPrefix, "TARGET_CACHE_PATH"))
+			},
+			Category: category,
+		},
+		// TODO: can we use a genericFlag for this, and automatically parse the string into a uint64?
+		&cli.StringFlag{
+			Name:    DeprecatedMaxBlobLengthFlagName,
+			Usage:   "Maximum blob length to be written or read from EigenDA. Determines the number of SRS points loaded into memory for KZG commitments. Example units: '30MiB', '4Kb', '30MB'. Maximum size slightly exceeds 1GB.",
+			EnvVars: withDeprecatedEnvPrefix(envPrefix, "MAX_BLOB_LENGTH"),
+			Value:   "16MiB",
+			Action: func(_ *cli.Context, _ string) error {
+				return fmt.Errorf("flag --%s (env var %s) is deprecated, use --%s (env var %s) instead",
+					DeprecatedMaxBlobLengthFlagName, withDeprecatedEnvPrefix(envPrefix, "MAX_BLOB_LENGTH"),
+					MaxBlobLengthFlagName, withEnvPrefix(envPrefix, "MAX_BLOB_LENGTH"))
+			},
+			// we also use this flag for memstore.
+			// should we duplicate the flag? Or is there a better way to handle this?
+			Category: category,
+		},
+	}
+}


### PR DESCRIPTION
Recent flags refactor PR changed a bunch of flags. Added some those deprecated flags back, crashing the program if they are ever used to force users to change to the new flags.

I'm sure I missed a bunch of flags though given that the flags have been dispersed locally in a bunch of different modules. Would be a tough job to make sure to get all the deprecated flags... I propose we leave it at this. @bxue-l2 wdyt?