### PR TITLE
Disable chunk encoding for `put` requests to Google Cloud Storage

### DIFF
--- a/store/precomputed_key/s3/s3.go
+++ b/store/precomputed_key/s3/s3.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"io"
+	"net/url"
 	"path"
 	"time"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/minio/minio-go/v7"
 
 	"github.com/minio/minio-go/v7/pkg/credentials"
+	"github.com/minio/minio-go/v7/pkg/s3utils"
 )
 
 const (
@@ -97,7 +99,16 @@ func (s *Store) Get(ctx context.Context, key []byte) ([]byte, error) {
 }
 
 func (s *Store) Put(ctx context.Context, key []byte, value []byte) error {
-	_, err := s.client.PutObject(ctx, s.cfg.Bucket, path.Join(s.cfg.Path, hex.EncodeToString(key)), bytes.NewReader(value), int64(len(value)), minio.PutObjectOptions{})
+	endpointURL, err := url.Parse(s.cfg.Endpoint)
+	if err != nil {
+		return err
+	}
+
+	putObjectOptions := minio.PutObjectOptions{}
+	if s3utils.IsGoogleEndpoint(*endpointURL) {
+		putObjectOptions.DisableContentSha256 = true // Avoid chunk signatures on GCS: https://github.com/minio/minio-go/issues/1922
+	}
+	_, err = s.client.PutObject(ctx, s.cfg.Bucket, path.Join(s.cfg.Path, hex.EncodeToString(key)), bytes.NewReader(value), int64(len(value)), putObjectOptions)
 	if err != nil {
 		return err
 	}

--- a/store/precomputed_key/s3/s3.go
+++ b/store/precomputed_key/s3/s3.go
@@ -52,12 +52,22 @@ type Config struct {
 }
 
 type Store struct {
-	cfg    Config
-	client *minio.Client
-	stats  *store.Stats
+	cfg              Config
+	client           *minio.Client
+	putObjectOptions minio.PutObjectOptions
+	stats            *store.Stats
 }
 
 func NewS3(cfg Config) (*Store, error) {
+	endpointURL, err := url.Parse(cfg.Endpoint)
+	if err != nil {
+		return nil, err
+	}
+	putObjectOptions := minio.PutObjectOptions{}
+	if s3utils.IsGoogleEndpoint(*endpointURL) {
+		putObjectOptions.DisableContentSha256 = true // Avoid chunk signatures on GCS: https://github.com/minio/minio-go/issues/1922
+	}
+
 	client, err := minio.New(cfg.Endpoint, &minio.Options{
 		Creds:  creds(cfg),
 		Secure: cfg.EnableTLS,
@@ -67,8 +77,9 @@ func NewS3(cfg Config) (*Store, error) {
 	}
 
 	return &Store{
-		cfg:    cfg,
-		client: client,
+		cfg:              cfg,
+		client:           client,
+		putObjectOptions: putObjectOptions,
 		stats: &store.Stats{
 			Entries: 0,
 			Reads:   0,
@@ -99,16 +110,7 @@ func (s *Store) Get(ctx context.Context, key []byte) ([]byte, error) {
 }
 
 func (s *Store) Put(ctx context.Context, key []byte, value []byte) error {
-	endpointURL, err := url.Parse(s.cfg.Endpoint)
-	if err != nil {
-		return err
-	}
-
-	putObjectOptions := minio.PutObjectOptions{}
-	if s3utils.IsGoogleEndpoint(*endpointURL) {
-		putObjectOptions.DisableContentSha256 = true // Avoid chunk signatures on GCS: https://github.com/minio/minio-go/issues/1922
-	}
-	_, err = s.client.PutObject(ctx, s.cfg.Bucket, path.Join(s.cfg.Path, hex.EncodeToString(key)), bytes.NewReader(value), int64(len(value)), putObjectOptions)
+	_, err := s.client.PutObject(ctx, s.cfg.Bucket, path.Join(s.cfg.Path, hex.EncodeToString(key)), bytes.NewReader(value), int64(len(value)), s.putObjectOptions)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #NNN` to link your PR with the
issue, replacing `#NNN` with the issue number you are fixing -->

## Fixes Issue

<!-- Example: Closes #NNN -->
Fixes #

## Changes proposed

<!-- List all the proposed changes in your PR -->
<!-- Add the screenshots of the changes below if applicable -->

The PR fixes the upload process on Google Storage (using its S3 compatibility API). Right now (with `main` config) the objects uploaded to Google Storage can have multiple `<size>;chunk-signature=<bytes>` strings in the file, which breaks the verification of the file on the get() stage.
Adding `DisableContentSha256 = true` to `putObjectOptions` used by minio client, the upload seems to be done properly and the chunk-signatures not included.

More info [here](https://github.com/minio/minio-go/issues/1922).

### Screenshots (Optional)

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
