### PR TITLE
Allow Google storage endpoints without http/s

### DIFF
--- a/store/precomputed_key/s3/s3.go
+++ b/store/precomputed_key/s3/s3.go
@@ -6,8 +6,8 @@ import (
 	"encoding/hex"
 	"errors"
 	"io"
-	"net/url"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/Layr-Labs/eigenda-proxy/store"
@@ -15,7 +15,6 @@ import (
 	"github.com/minio/minio-go/v7"
 
 	"github.com/minio/minio-go/v7/pkg/credentials"
-	"github.com/minio/minio-go/v7/pkg/s3utils"
 )
 
 const (
@@ -58,13 +57,13 @@ type Store struct {
 	stats            *store.Stats
 }
 
+func isGoogleEndpoint(endpoint string) bool {
+	return strings.Contains(endpoint, "storage.googleapis.com")
+}
+
 func NewS3(cfg Config) (*Store, error) {
-	endpointURL, err := url.Parse(cfg.Endpoint)
-	if err != nil {
-		return nil, err
-	}
 	putObjectOptions := minio.PutObjectOptions{}
-	if s3utils.IsGoogleEndpoint(*endpointURL) {
+	if isGoogleEndpoint(cfg.Endpoint) {
 		putObjectOptions.DisableContentSha256 = true // Avoid chunk signatures on GCS: https://github.com/minio/minio-go/issues/1922
 	}
 

--- a/store/precomputed_key/s3/s3_test.go
+++ b/store/precomputed_key/s3/s3_test.go
@@ -1,0 +1,31 @@
+package s3
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsGoogleEndpoint_StorageGoogleapis(t *testing.T) {
+	endpoint := "storage.googleapis.com"
+	result := isGoogleEndpoint(endpoint)
+	assert.True(t, result, "Expected true for Google Cloud Storage endpoint")
+}
+
+func TestIsGoogleEndpoint_HttpsStorageGoogleapis(t *testing.T) {
+	endpoint := "https://storage.googleapis.com"
+	result := isGoogleEndpoint(endpoint)
+	assert.True(t, result, "Expected true for Google Cloud Storage endpoint")
+}
+
+func TestIsGoogleEndpoint_False(t *testing.T) {
+	endpoint := "https://s3.amazonaws.com/my-bucket"
+	result := isGoogleEndpoint(endpoint)
+	assert.False(t, result, "Expected false for non-Google endpoint")
+}
+
+func TestIsGoogleEndpoint_Empty(t *testing.T) {
+	endpoint := ""
+	result := isGoogleEndpoint(endpoint)
+	assert.False(t, result, "Expected false for empty endpoint")
+}


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #NNN` to link your PR with the
issue, replacing `#NNN` with the issue number you are fixing -->

## Fixes Issue

The line `endpointURL, err := url.Parse(cfg.Endpoint)` does not properly parse the URL if the parameter does not include the protocol (http/https). This is problematic because the protocol cannot be included when initializing the S3/MinIO client; otherwise, you get the following error:

```
t=2024-10-09T08:31:27+0000 lvl=crit msg="Application failed" role=eigenda_proxy message="failed to create store: failed to create S3 store: Endpoint url cannot have fully qualified paths."
```

## Changes proposed

A small refactor to simplify the Google Storage endpoint checker.

### Screenshots (Optional)

## Note to reviewers

For the simple tests added, I’ve only focused on the `isGoogleEndpoint()` method. While https://storage.googleapis.com is not a valid URL for `minio.New()`, I skipped checking for that in this function. If you'd prefer, I can include a check in `server/config.go` to ensure that the protocol is absent in the config provided.
Sorry about the noise/multiple PRs.