### PR TITLE
fix(ci): update go1.21->1.22 everywhere

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21
+        go-version: 1.22
 
     - name: Build App
       run: make eigenda-proxy

--- a/.github/workflows/holesky-test.yml
+++ b/.github/workflows/holesky-test.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21
+        go-version: 1.22
 
     - name: Install project dependencies
       run: | 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.21' # The Go version to download (if necessary) and use.
+          go-version: '1.22' # The Go version to download (if necessary) and use.
       - run: go version
 
       - name: Checkout EigenDA

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21
+        go-version: 1.22
 
     - name: Install project dependencies
       run: | 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # multi container builds ftw
 
-FROM golang:1.21.10-alpine3.19 AS builder
+FROM golang:1.22.8-alpine3.19 AS builder
 
 RUN apk add --no-cache make gcc musl-dev linux-headers jq bash git
 


### PR DESCRIPTION
We updated go.mod to use go1.22 recently, but forgot to update the ci workflows.
Here's an example of a broken workflow: https://github.com/Layr-Labs/eigenda-proxy/actions/runs/11304509810/job/31449520854

<!-- If your PR fixes an open issue, use `Closes #NNN` to link your PR with the
issue, replacing `#NNN` with the issue number you are fixing -->

## Fixes Issue

<!-- Example: Closes #NNN -->
Fixes #

## Changes proposed

<!-- List all the proposed changes in your PR -->
<!-- Add the screenshots of the changes below if applicable -->

### Screenshots (Optional)

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
