### PR TITLE
fix: fetch quorum parameters from edasm at RBN instead of latest block

### DIFF
--- a/verify/verifier.go
+++ b/verify/verifier.go
@@ -2,10 +2,12 @@ package verify
 
 import (
 	"fmt"
+	"math/big"
 
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark-crypto/ecc/bn254"
 	"github.com/consensys/gnark-crypto/ecc/bn254/fp"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/log"
 
 	binding "github.com/Layr-Labs/eigenda/contracts/bindings/EigenDAServiceManager"
@@ -149,8 +151,9 @@ func (v *Verifier) VerifySecurityParams(blobHeader BlobHeader, batchHeader bindi
 		if blobHeader.QuorumBlobParams[i].AdversaryThresholdPercentage > blobHeader.QuorumBlobParams[i].ConfirmationThresholdPercentage {
 			return fmt.Errorf("adversary threshold percentage must be greater than or equal to confirmation threshold percentage")
 		}
-
-		quorumAdversaryThreshold, err := v.getQuorumAdversaryThreshold(blobHeader.QuorumBlobParams[i].QuorumNumber)
+		// we get the quorum adversary threshold at the batch's reference block number, since that is the parameter
+		// that the eigenda disperser used to verify the batch signature's validity
+		quorumAdversaryThreshold, err := v.getQuorumAdversaryThreshold(blobHeader.QuorumBlobParams[i].QuorumNumber, int64(batchHeader.ReferenceBlockNumber))
 		if err != nil {
 			log.Warn("failed to get quorum adversary threshold", "err", err)
 		}
@@ -166,9 +169,9 @@ func (v *Verifier) VerifySecurityParams(blobHeader BlobHeader, batchHeader bindi
 		confirmedQuorums[blobHeader.QuorumBlobParams[i].QuorumNumber] = true
 	}
 
-	requiredQuorums, err := v.cv.manager.QuorumNumbersRequired(nil)
+	requiredQuorums, err := v.cv.manager.QuorumNumbersRequired(&bind.CallOpts{BlockNumber: big.NewInt(int64(batchHeader.ReferenceBlockNumber))})
 	if err != nil {
-		log.Warn("failed to get required quorum numbers", "err", err)
+		log.Warn("failed to get required quorum numbers at block number", "err", err, "referenceBlockNumber", batchHeader.ReferenceBlockNumber)
 	}
 
 	// ensure that required quorums are present in the confirmed ones
@@ -181,10 +184,10 @@ func (v *Verifier) VerifySecurityParams(blobHeader BlobHeader, batchHeader bindi
 	return nil
 }
 
-// getQuorumAdversaryThreshold reads the adversarial threshold percentage for a given quorum number
-// returns 0 if DNE
-func (v *Verifier) getQuorumAdversaryThreshold(quorumNum uint8) (uint8, error) {
-	percentages, err := v.cv.manager.QuorumAdversaryThresholdPercentages(nil)
+// getQuorumAdversaryThreshold reads the adversarial threshold percentage for a given quorum number,
+// at a given block number. If the quorum number does not exist, it returns 0.
+func (v *Verifier) getQuorumAdversaryThreshold(quorumNum uint8, blockNumber int64) (uint8, error) {
+	percentages, err := v.cv.manager.QuorumAdversaryThresholdPercentages(&bind.CallOpts{BlockNumber: big.NewInt(blockNumber)})
 	if err != nil {
 		return 0, err
 	}

--- a/verify/verifier.go
+++ b/verify/verifier.go
@@ -151,8 +151,9 @@ func (v *Verifier) VerifySecurityParams(blobHeader BlobHeader, batchHeader bindi
 		if blobHeader.QuorumBlobParams[i].AdversaryThresholdPercentage > blobHeader.QuorumBlobParams[i].ConfirmationThresholdPercentage {
 			return fmt.Errorf("adversary threshold percentage must be greater than or equal to confirmation threshold percentage")
 		}
-		// we get the quorum adversary threshold at the batch's reference block number, since that is the parameter
-		// that the eigenda disperser used to verify the batch signature's validity
+		// we get the quorum adversary threshold at the batch's reference block number. This is not strictly needed right now
+		// since this threshold is hardcoded into the contract: https://github.com/Layr-Labs/eigenda/blob/master/contracts/src/core/EigenDAServiceManagerStorage.sol
+		// but it is good practice in case the contract changes in the future
 		quorumAdversaryThreshold, err := v.getQuorumAdversaryThreshold(blobHeader.QuorumBlobParams[i].QuorumNumber, int64(batchHeader.ReferenceBlockNumber))
 		if err != nil {
 			log.Warn("failed to get quorum adversary threshold", "err", err)


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #NNN` to link your PR with the
issue, replacing `#NNN` with the issue number you are fixing -->

## Fixes Issue

Think this is a bug... but not 100% sure. So please verify that this is correct.

<!-- Example: Closes #NNN -->
Fixes #

## Changes proposed

<!-- List all the proposed changes in your PR -->
<!-- Add the screenshots of the changes below if applicable -->

### Screenshots (Optional)

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
