### PR TITLE
refactor: use batch confirmation that was upstreamed to eigenda client

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,11 +16,11 @@ jobs:
           go-version: '1.22' # The Go version to download (if necessary) and use.
       - run: go version
 
-      - name: Checkout EigenDA
+      - name: Checkout code
         uses: actions/checkout@v3
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.60
+          version: v1.61
           args: --timeout 3m

--- a/flags/eigendaflags/cli.go
+++ b/flags/eigendaflags/cli.go
@@ -1,6 +1,8 @@
 package eigendaflags
 
 import (
+	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/Layr-Labs/eigenda/api/clients"
@@ -21,6 +23,9 @@ var (
 	PutBlobEncodingVersionFlagName       = withFlagPrefix("put-blob-encoding-version")
 	DisablePointVerificationModeFlagName = withFlagPrefix("disable-point-verification-mode")
 	WaitForFinalizationFlagName          = withFlagPrefix("wait-for-finalization")
+	ConfirmationDepthFlagName            = withFlagPrefix("confirmation-depth")
+	EthRPCURLFlagName                    = withFlagPrefix("eth-rpc")
+	SvcManagerAddrFlagName               = withFlagPrefix("svc-manager-addr")
 )
 
 func withFlagPrefix(s string) string {
@@ -101,11 +106,41 @@ func CLIFlags(envPrefix, category string) []cli.Flag {
 			EnvVars:  []string{withEnvPrefix(envPrefix, "WAIT_FOR_FINALIZATION")},
 			Value:    false,
 			Category: category,
+			Hidden:   true,
+			Action: func(_ *cli.Context, _ bool) error {
+				return fmt.Errorf("flag --%s is deprecated, instead use --%s finalized", WaitForFinalizationFlagName, ConfirmationDepthFlagName)
+			},
+		},
+		&cli.StringFlag{
+			Name: ConfirmationDepthFlagName,
+			Usage: "Number of Ethereum blocks to wait after the blob's batch has been included on-chain, " +
+				"before returning from PutBlob calls. Can either be a number or 'finalized'.",
+			EnvVars:  []string{withEnvPrefix(envPrefix, "CONFIRMATION_DEPTH")},
+			Value:    "0",
+			Category: category,
+			Action: func(ctx *cli.Context, val string) error {
+				return validateConfirmationFlag(val)
+			},
+		},
+		&cli.StringFlag{
+			Name:     EthRPCURLFlagName,
+			Usage:    "URL of the Ethereum RPC endpoint. Needed to confirm blobs landed onchain.",
+			EnvVars:  []string{withEnvPrefix(envPrefix, "ETH_RPC")},
+			Category: category,
+			Required: true,
+		},
+		&cli.StringFlag{
+			Name:     SvcManagerAddrFlagName,
+			Usage:    "Address of the EigenDAServiceManager contract. Required to confirm blobs landed onchain. See https://github.com/Layr-Labs/eigenlayer-middleware/?tab=readme-ov-file#current-mainnet-deployment",
+			EnvVars:  []string{withEnvPrefix(envPrefix, "SERVICE_MANAGER_ADDR")},
+			Category: category,
+			Required: true,
 		},
 	}
 }
 
 func ReadConfig(ctx *cli.Context) clients.EigenDAClientConfig {
+	waitForFinalization, confirmationDepth := parseConfirmationFlag(ctx.String(ConfirmationDepthFlagName))
 	return clients.EigenDAClientConfig{
 		RPC:                          ctx.String(DisperserRPCFlagName),
 		StatusQueryRetryInterval:     ctx.Duration(StatusQueryRetryIntervalFlagName),
@@ -116,6 +151,40 @@ func ReadConfig(ctx *cli.Context) clients.EigenDAClientConfig {
 		SignerPrivateKeyHex:          ctx.String(SignerPrivateKeyHexFlagName),
 		PutBlobEncodingVersion:       codecs.BlobEncodingVersion(ctx.Uint(PutBlobEncodingVersionFlagName)),
 		DisablePointVerificationMode: ctx.Bool(DisablePointVerificationModeFlagName),
-		WaitForFinalization:          ctx.Bool(WaitForFinalizationFlagName),
+		WaitForFinalization:          waitForFinalization,
+		WaitForConfirmationDepth:     confirmationDepth,
+		EthRpcUrl:                    ctx.String(EthRPCURLFlagName),
+		SvcManagerAddr:               ctx.String(SvcManagerAddrFlagName),
 	}
+}
+
+// Helper to parse the flag value into config fields
+func parseConfirmationFlag(val string) (waitForFinalization bool, confirmationDepth uint64) {
+	if val == "finalized" {
+		return true, 0
+	}
+
+	depth, err := strconv.ParseUint(val, 10, 64)
+	if err != nil {
+		panic("this should never happen, as the flag is validated before this point")
+	}
+
+	return false, depth
+}
+
+func validateConfirmationFlag(val string) error {
+	if val == "finalized" {
+		return nil
+	}
+
+	depth, err := strconv.ParseUint(val, 10, 64)
+	if err != nil {
+		return fmt.Errorf("confirmation-depth must be either 'finalized' or a number, got: %s", val)
+	}
+
+	if depth >= 64 {
+		fmt.Printf("Warning: confirmation depth set to %d, which is > 2 epochs (64). Consider using 'finalized' instead.\n", depth)
+	}
+
+	return nil
 }

--- a/flags/eigendaflags/cli.go
+++ b/flags/eigendaflags/cli.go
@@ -2,6 +2,7 @@ package eigendaflags
 
 import (
 	"fmt"
+	"log"
 	"strconv"
 	"time"
 
@@ -118,7 +119,7 @@ func CLIFlags(envPrefix, category string) []cli.Flag {
 			EnvVars:  []string{withEnvPrefix(envPrefix, "CONFIRMATION_DEPTH")},
 			Value:    "0",
 			Category: category,
-			Action: func(ctx *cli.Context, val string) error {
+			Action: func(_ *cli.Context, val string) error {
 				return validateConfirmationFlag(val)
 			},
 		},
@@ -158,8 +159,8 @@ func ReadConfig(ctx *cli.Context) clients.EigenDAClientConfig {
 	}
 }
 
-// Helper to parse the flag value into config fields
-func parseConfirmationFlag(val string) (waitForFinalization bool, confirmationDepth uint64) {
+// parse the val (either "finalized" or a number) into waitForFinalization (bool) and confirmationDepth (uint64).
+func parseConfirmationFlag(val string) (bool, uint64) {
 	if val == "finalized" {
 		return true, 0
 	}
@@ -183,7 +184,7 @@ func validateConfirmationFlag(val string) error {
 	}
 
 	if depth >= 64 {
-		fmt.Printf("Warning: confirmation depth set to %d, which is > 2 epochs (64). Consider using 'finalized' instead.\n", depth)
+		log.Printf("Warning: confirmation depth set to %d, which is > 2 epochs (64). Consider using 'finalized' instead.\n", depth)
 	}
 
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,7 @@ go 1.22
 toolchain go1.22.0
 
 require (
-	// pointing to latest commit of https://github.com/Layr-Labs/eigenda/pull/821
-	// TODO: merge eigenda-client PR first, and then point to the latest master commit
-	//       instead of PR commit (which will get squash and merged)
-	github.com/Layr-Labs/eigenda v0.8.5-0.20241025110857-96ad889d3c17
+	github.com/Layr-Labs/eigenda v0.8.5-0.20241028201743-5fe3e910a22d
 	github.com/consensys/gnark-crypto v0.12.1
 	github.com/ethereum-optimism/optimism v1.9.4-0.20240927020138-a9c7f349d10b
 	github.com/ethereum/go-ethereum v1.14.11
@@ -42,6 +39,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.5 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.5 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.31.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.11.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.11.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/kms v1.31.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,10 @@ go 1.22
 toolchain go1.22.0
 
 require (
-	github.com/Layr-Labs/eigenda v0.8.4
+	// pointing to latest commit of https://github.com/Layr-Labs/eigenda/pull/821
+	// TODO: merge eigenda-client PR first, and then point to the latest master commit
+	//       instead of PR commit (which will get squash and merged)
+	github.com/Layr-Labs/eigenda v0.8.5-0.20241025110857-96ad889d3c17
 	github.com/consensys/gnark-crypto v0.12.1
 	github.com/ethereum-optimism/optimism v1.9.4-0.20240927020138-a9c7f349d10b
 	github.com/ethereum/go-ethereum v1.14.11
@@ -173,7 +176,7 @@ require (
 	github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/mattn/go-runewidth v0.0.14 // indirect
+	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/miekg/dns v1.1.62 // indirect
 	github.com/mikioh/tcpinfo v0.0.0-20190314235526-30a79bb1804b // indirect
 	github.com/mikioh/tcpopt v0.0.0-20190314235656-172688c1accc // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.5.6-0.20230824185856-869dae002e5e h1:ZIWapoIRN1VqT8GR8jAwb1Ie9GyehWjVcGh32Y2MznE=
 github.com/DataDog/zstd v1.5.6-0.20230824185856-869dae002e5e/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
-github.com/Layr-Labs/eigenda v0.8.5-0.20241025110857-96ad889d3c17 h1:XgGgyega487NOpg0Ko7GdyyuxQykpzLrqPfUz7RURgY=
-github.com/Layr-Labs/eigenda v0.8.5-0.20241025110857-96ad889d3c17/go.mod h1:sqUNf9Ak+EfAX82jDxrb4QbT/g3DViWD3b7YIk36skk=
+github.com/Layr-Labs/eigenda v0.8.5-0.20241028201743-5fe3e910a22d h1:s5U1TaWhC1J2rwc9IQdU/COGvuXALCKMd9GbONUZMxc=
+github.com/Layr-Labs/eigenda v0.8.5-0.20241028201743-5fe3e910a22d/go.mod h1:sqUNf9Ak+EfAX82jDxrb4QbT/g3DViWD3b7YIk36skk=
 github.com/Layr-Labs/eigensdk-go v0.1.7-0.20240507215523-7e4891d5099a h1:L/UsJFw9M31FD/WgXTPFB0oxbq9Cu4Urea1xWPMQS7Y=
 github.com/Layr-Labs/eigensdk-go v0.1.7-0.20240507215523-7e4891d5099a/go.mod h1:OF9lmS/57MKxS0xpSpX0qHZl0SKkDRpvJIvsGvMN1y8=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.5.6-0.20230824185856-869dae002e5e h1:ZIWapoIRN1VqT8GR8jAwb1Ie9GyehWjVcGh32Y2MznE=
 github.com/DataDog/zstd v1.5.6-0.20230824185856-869dae002e5e/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
-github.com/Layr-Labs/eigenda v0.8.4 h1:6znMJcPLtchYixbUddCeKCKqwbpsAf/4CX/fBnWlIpc=
-github.com/Layr-Labs/eigenda v0.8.4/go.mod h1:MzSFbxDQ1/tMcLlfxqz08YubB3rd+E2xme2p7hwP2YM=
+github.com/Layr-Labs/eigenda v0.8.5-0.20241025110857-96ad889d3c17 h1:XgGgyega487NOpg0Ko7GdyyuxQykpzLrqPfUz7RURgY=
+github.com/Layr-Labs/eigenda v0.8.5-0.20241025110857-96ad889d3c17/go.mod h1:sqUNf9Ak+EfAX82jDxrb4QbT/g3DViWD3b7YIk36skk=
 github.com/Layr-Labs/eigensdk-go v0.1.7-0.20240507215523-7e4891d5099a h1:L/UsJFw9M31FD/WgXTPFB0oxbq9Cu4Urea1xWPMQS7Y=
 github.com/Layr-Labs/eigensdk-go v0.1.7-0.20240507215523-7e4891d5099a/go.mod h1:OF9lmS/57MKxS0xpSpX0qHZl0SKkDRpvJIvsGvMN1y8=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
@@ -583,8 +583,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
-github.com/mattn/go-runewidth v0.0.14 h1:+xnbZSEeDbOIg5/mE6JF0w6n9duR1l3/WmbinWVwUuU=
-github.com/mattn/go-runewidth v0.0.14/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
+github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
+github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/microcosm-cc/bluemonday v1.0.1/go.mod h1:hsXNsILzKxV+sX77C5b8FSuKF00vh2OMYv+xgHpAMF4=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=

--- a/server/config.go
+++ b/server/config.go
@@ -37,11 +37,12 @@ type Config struct {
 
 // ReadConfig ... parses the Config from the provided flags or environment variables.
 func ReadConfig(ctx *cli.Context) Config {
+	edaClientConfig := eigendaflags.ReadConfig(ctx)
 	return Config{
 		RedisConfig:     redis.ReadConfig(ctx),
 		S3Config:        s3.ReadConfig(ctx),
-		EdaClientConfig: eigendaflags.ReadConfig(ctx),
-		VerifierConfig:  verify.ReadConfig(ctx),
+		EdaClientConfig: edaClientConfig,
+		VerifierConfig:  verify.ReadConfig(ctx, edaClientConfig),
 		MemstoreEnabled: ctx.Bool(memstore.EnabledFlagName),
 		MemstoreConfig:  memstore.ReadConfig(ctx),
 		FallbackTargets: ctx.StringSlice(flags.FallbackTargetsFlagName),
@@ -80,7 +81,7 @@ func (cfg *Config) Check() error {
 	// TODO: move this verification logic to verify/cli.go
 	if cfg.VerifierConfig.VerifyCerts {
 		if cfg.MemstoreEnabled {
-			return fmt.Errorf("cannot enable cert verification when memstore is enabled")
+			return fmt.Errorf("cannot enable cert verification when memstore is enabled. use --%s", verify.CertVerificationDisabledFlagName)
 		}
 		if cfg.VerifierConfig.RPCURL == "" {
 			return fmt.Errorf("cert verification enabled but eth rpc is not set")

--- a/store/generated_key/memstore/memstore.go
+++ b/store/generated_key/memstore/memstore.go
@@ -218,7 +218,7 @@ func (e *MemStore) Put(_ context.Context, value []byte) ([]byte, error) {
 	return certBytes, nil
 }
 
-func (e *MemStore) Verify(_, _ []byte) error {
+func (e *MemStore) Verify(_ context.Context, _, _ []byte) error {
 	return nil
 }
 

--- a/store/manager.go
+++ b/store/manager.go
@@ -56,7 +56,7 @@ func (m *Manager) Get(ctx context.Context, key []byte, cm commitments.Commitment
 		}
 
 		// 2 - verify blob hash against commitment key digest
-		err = m.s3.Verify(key, value)
+		err = m.s3.Verify(ctx, key, value)
 		if err != nil {
 			return nil, err
 		}
@@ -82,7 +82,7 @@ func (m *Manager) Get(ctx context.Context, key []byte, cm commitments.Commitment
 		data, err := m.eigenda.Get(ctx, key)
 		if err == nil {
 			// verify
-			err = m.eigenda.Verify(key, data)
+			err = m.eigenda.Verify(ctx, key, data)
 			if err != nil {
 				return nil, err
 			}
@@ -158,7 +158,7 @@ func (m *Manager) putKeccak256Mode(ctx context.Context, key []byte, value []byte
 		return nil, errors.New("S3 is disabled but is only supported for posting known commitment keys")
 	}
 
-	err := m.s3.Verify(key, value)
+	err := m.s3.Verify(ctx, key, value)
 	if err != nil {
 		return nil, err
 	}

--- a/store/precomputed_key/redis/redis.go
+++ b/store/precomputed_key/redis/redis.go
@@ -71,7 +71,7 @@ func (r *Store) Put(ctx context.Context, key []byte, value []byte) error {
 	return r.client.Set(ctx, string(key), string(value), r.eviction).Err()
 }
 
-func (r *Store) Verify(_ []byte, _ []byte) error {
+func (r *Store) Verify(_ context.Context, _, _ []byte) error {
 	return nil
 }
 

--- a/store/precomputed_key/s3/s3.go
+++ b/store/precomputed_key/s3/s3.go
@@ -107,7 +107,7 @@ func (s *Store) Put(ctx context.Context, key []byte, value []byte) error {
 	return nil
 }
 
-func (s *Store) Verify(key []byte, value []byte) error {
+func (s *Store) Verify(_ context.Context, key []byte, value []byte) error {
 	h := crypto.Keccak256Hash(value)
 	if !bytes.Equal(h[:], key) {
 		return fmt.Errorf("key does not match value, expected: %s got: %s", hex.EncodeToString(key), h.Hex())

--- a/store/store.go
+++ b/store/store.go
@@ -68,7 +68,7 @@ type Store interface {
 	// Backend returns the backend type provider of the store.
 	BackendType() BackendType
 	// Verify verifies the given key-value pair.
-	Verify(key []byte, value []byte) error
+	Verify(ctx context.Context, key []byte, value []byte) error
 }
 
 type GeneratedKeyStore interface {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -28,20 +28,6 @@ func Contains[P comparable](s []P, e P) bool {
 	return false
 }
 
-func EqualSlices[P comparable](s1, s2 []P) bool {
-	if len(s1) != len(s2) {
-		return false
-	}
-
-	for i := 0; i < len(s1); i++ {
-		if s1[i] != s2[i] {
-			return false
-		}
-	}
-
-	return true
-}
-
 func ParseBytesAmount(s string) (uint64, error) {
 	s = strings.TrimSpace(s)
 

--- a/verify/cert.go
+++ b/verify/cert.go
@@ -62,7 +62,7 @@ func (cv *CertVerifier) verifyBatchConfirmedOnChain(
 	// no longer valid. The eigenda batcher does check for these reorgs and updates the batch's confirmation block number:
 	// https://github.com/Layr-Labs/eigenda/blob/bee55ed9207f16153c3fd8ebf73c219e68685def/disperser/batcher/finalizer.go#L198
 	// TODO: We could require the disperser for the new batch, or try to reconstruct it ourselves by querying the chain,
-	// but for now we opt to simply fail the verification, which will force teh batcher to resubmit the batch to eigenda.
+	// but for now we opt to simply fail the verification, which will force the batcher to resubmit the batch to eigenda.
 	confirmationBlockNumber := batchMetadata.GetConfirmationBlockNumber()
 	confirmationBlockNumberBigInt := big.NewInt(0).SetInt64(int64(confirmationBlockNumber))
 	_, err := cv.retrieveBatchMetadataHash(ctx, batchID, confirmationBlockNumberBigInt)
@@ -73,7 +73,7 @@ func (cv *CertVerifier) verifyBatchConfirmedOnChain(
 	// 2. Verify that the confirmation status has been reached.
 	// The eigenda-client already checks for this, but it is possible for either
 	//  1. a reorg to happen, causing the batch to be confirmed by fewer number of blocks than required
-	//  2. proxy's node is behind the eigenda_client's node that deemed the batch confirmed, or 
+	//  2. proxy's node is behind the eigenda_client's node that deemed the batch confirmed, or
 	//     even if we use the same url, that the connection drops and we get load-balanced to a different eth node.
 	// We retry up to 60 seconds (allowing for reorgs up to 5 blocks deep), but we only wait 3 seconds between each retry,
 	// in case (2) is the case and the node simply needs to resync, which could happen fast.

--- a/verify/cert.go
+++ b/verify/cert.go
@@ -3,26 +3,28 @@ package verify
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"math/big"
+	"time"
 
+	"github.com/Layr-Labs/eigenda/api/grpc/disperser"
 	binding "github.com/Layr-Labs/eigenda/contracts/bindings/EigenDAServiceManager"
+
+	"github.com/ethereum-optimism/optimism/op-service/retry"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 	"golang.org/x/exp/slices"
 )
-
-var ErrBatchMetadataHashNotFound = errors.New("BatchMetadataHash not found for BatchId")
 
 // CertVerifier verifies the DA certificate against on-chain EigenDA contracts
 // to ensure disperser returned fields haven't been tampered with
 type CertVerifier struct {
 	l                    log.Logger
 	ethConfirmationDepth uint64
+	waitForFinalization  bool
 	manager              *binding.ContractEigenDAServiceManagerCaller
 	ethClient            *ethclient.Client
 }
@@ -49,40 +51,60 @@ func NewCertVerifier(cfg *Config, l log.Logger) (*CertVerifier, error) {
 	}, nil
 }
 
-// verifies on-chain batch ID for equivalence to certificate batch header fields
-func (cv *CertVerifier) VerifyBatch(
-	header *binding.IEigenDAServiceManagerBatchHeader, id uint32, recordHash [32]byte, confirmationNumber uint32,
+// verifyBatchConfirmedOnChain verifies that batchMetadata (typically part of a received cert)
+// matches the batch metadata hash stored on-chain
+func (cv *CertVerifier) verifyBatchConfirmedOnChain(
+	ctx context.Context, batchID uint32, batchMetadata *disperser.BatchMetadata,
 ) error {
-	blockNumber, err := cv.getConfDeepBlockNumber()
+	// 1. verify batch is actually onchain at the batchMetadata's state confirmedBlockNumber
+	// This assert is technically not necessary, but it's a good sanity check.
+	// It could technically happen that a confirmed batch's block gets reorged out,
+	// yet the tx is included in an earlier or later block, making this check fail...
+	confirmationBlockNumber := batchMetadata.GetConfirmationBlockNumber()
+	confirmationBlockNumberBigInt := big.NewInt(0).SetInt64(int64(confirmationBlockNumber))
+	_, err := cv.retrieveBatchMetadataHash(ctx, batchID, confirmationBlockNumberBigInt)
 	if err != nil {
-		return fmt.Errorf("failed to get context block: %w", err)
+		return fmt.Errorf("batch not found onchain at supposedly confirmed block %d: %w", confirmationBlockNumber, err)
 	}
 
-	// 1. ensure that a batch hash can be looked up for a batch ID for a given block number
-	expectedHash, err := cv.manager.BatchIdToBatchMetadataHash(&bind.CallOpts{BlockNumber: blockNumber}, id)
+	// 2. verify that the confirmation status has been reached
+	// We retry 5 times waiting 12 seconds (block time) between each retry,
+	// in case our eth node is behind that of the eigenda_client's node that deemed the batch confirmed
+	onchainHash, err := retry.Do(ctx, 5, retry.Fixed(12*time.Second), func() ([32]byte, error) {
+		blockNumber, err := cv.getConfDeepBlockNumber(ctx)
+		if err != nil {
+			return [32]byte{}, fmt.Errorf("failed to get context block: %w", err)
+		}
+		return cv.retrieveBatchMetadataHash(ctx, batchID, blockNumber)
+	})
 	if err != nil {
-		return fmt.Errorf("failed to get batch metadata hash: %w", err)
-	}
-	if bytes.Equal(expectedHash[:], make([]byte, 32)) {
-		return ErrBatchMetadataHashNotFound
+		return fmt.Errorf("retrieving batch that was confirmed at block %v: %w", confirmationBlockNumber, err)
 	}
 
-	// 2. ensure that hash generated from local cert matches one stored on-chain
-	actualHash, err := HashBatchMetadata(header, recordHash, confirmationNumber)
+	// 3. compute the hash of the batch metadata received as argument
+	header := &binding.IEigenDAServiceManagerBatchHeader{
+		BlobHeadersRoot:       [32]byte(batchMetadata.GetBatchHeader().GetBatchRoot()),
+		QuorumNumbers:         batchMetadata.GetBatchHeader().GetQuorumNumbers(),
+		ReferenceBlockNumber:  batchMetadata.GetBatchHeader().GetReferenceBlockNumber(),
+		SignedStakeForQuorums: batchMetadata.GetBatchHeader().GetQuorumSignedPercentages(),
+	}
+	recordHash := [32]byte(batchMetadata.GetSignatoryRecordHash())
+	computedHash, err := HashBatchMetadata(header, recordHash, confirmationBlockNumber)
 	if err != nil {
 		return fmt.Errorf("failed to hash batch metadata: %w", err)
 	}
 
-	equal := slices.Equal(expectedHash[:], actualHash[:])
+	// 4. ensure that hash generated from local cert matches one stored on-chain
+	equal := slices.Equal(onchainHash[:], computedHash[:])
 	if !equal {
-		return fmt.Errorf("batch hash mismatch, expected: %x, got: %x", expectedHash, actualHash)
+		return fmt.Errorf("batch hash mismatch, onchain: %x, computed: %x", onchainHash, computedHash)
 	}
 
 	return nil
 }
 
 // verifies the blob batch inclusion proof against the blob root hash
-func (cv *CertVerifier) VerifyMerkleProof(inclusionProof []byte, root []byte,
+func (cv *CertVerifier) verifyMerkleProof(inclusionProof []byte, root []byte,
 	blobIndex uint32, blobHeader BlobHeader) error {
 	leafHash, err := HashEncodeBlobHeader(blobHeader)
 	if err != nil {
@@ -103,10 +125,37 @@ func (cv *CertVerifier) VerifyMerkleProof(inclusionProof []byte, root []byte,
 }
 
 // fetches a block number provided a subtraction of a user defined conf depth from latest block
-func (cv *CertVerifier) getConfDeepBlockNumber() (*big.Int, error) {
-	blockNumber, err := cv.ethClient.BlockNumber(context.Background())
+func (cv *CertVerifier) getConfDeepBlockNumber(ctx context.Context) (*big.Int, error) {
+	if cv.waitForFinalization {
+		var header = types.Header{}
+		// We ask for the latest finalized block. The second parameter "hydrated txs" is set to false because we don't need full txs.
+		// See https://github.com/ethereum/execution-apis/blob/4140e528360fea53c34a766d86a000c6c039100e/src/eth/block.yaml#L61
+		// This is equivalent to `cast block finalized`, as opposed to `cast block finalized --full`.
+		err := cv.ethClient.Client().CallContext(ctx, &header, "eth_getBlockByNumber", "finalized", false)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get finalized block: %w", err)
+		}
+		return header.Number, nil
+	}
+	blockNumber, err := cv.ethClient.BlockNumber(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get latest block number: %w", err)
 	}
-	return new(big.Int).SetUint64(max(blockNumber-cv.ethConfirmationDepth, 0)), nil
+	if blockNumber < cv.ethConfirmationDepth {
+		return big.NewInt(0), nil
+	}
+	return new(big.Int).SetUint64(blockNumber - cv.ethConfirmationDepth), nil
+}
+
+// retrieveBatchMetadataHash retrieves the batch metadata hash stored on-chain at a specific blockNumber for a given batchID
+// returns an error if some problem calling the contract happens, or the hash is not found
+func (cv *CertVerifier) retrieveBatchMetadataHash(ctx context.Context, batchID uint32, blockNumber *big.Int) ([32]byte, error) {
+	onchainHash, err := cv.manager.BatchIdToBatchMetadataHash(&bind.CallOpts{Context: ctx, BlockNumber: blockNumber}, batchID)
+	if err != nil {
+		return [32]byte{}, fmt.Errorf("calling EigenDAServiceManager.BatchIdToBatchMetadataHash: %w", err)
+	}
+	if bytes.Equal(onchainHash[:], make([]byte, 32)) {
+		return [32]byte{}, fmt.Errorf("BatchMetadataHash not found for BatchId %d at block %d", batchID, blockNumber.Uint64())
+	}
+	return onchainHash, nil
 }

--- a/verify/deprecated_flags.go
+++ b/verify/deprecated_flags.go
@@ -3,6 +3,7 @@ package verify
 import (
 	"fmt"
 
+	"github.com/Layr-Labs/eigenda-proxy/flags/eigendaflags"
 	"github.com/urfave/cli/v2"
 )
 
@@ -41,7 +42,7 @@ func DeprecatedCLIFlags(envPrefix, category string) []cli.Flag {
 			Action: func(_ *cli.Context, _ string) error {
 				return fmt.Errorf("flag --%s (env var %s) is deprecated, use --%s (env var %s) instead",
 					DeprecatedEthRPCFlagName, withDeprecatedEnvPrefix(envPrefix, "ETH_RPC"),
-					EthRPCFlagName, withEnvPrefix(envPrefix, "ETH_RPC"))
+					eigendaflags.EthRPCURLFlagName, withEnvPrefix(envPrefix, "ETH_RPC"))
 			},
 			Category: category,
 		},
@@ -52,7 +53,7 @@ func DeprecatedCLIFlags(envPrefix, category string) []cli.Flag {
 			Action: func(_ *cli.Context, _ string) error {
 				return fmt.Errorf("flag --%s (env var %s) is deprecated, use --%s (env var %s) instead",
 					DeprecatedSvcManagerAddrFlagName, withDeprecatedEnvPrefix(envPrefix, "SERVICE_MANAGER_ADDR"),
-					SvcManagerAddrFlagName, withEnvPrefix(envPrefix, "SERVICE_MANAGER_ADDR"))
+					eigendaflags.SvcManagerAddrFlagName, withEnvPrefix(envPrefix, "SERVICE_MANAGER_ADDR"))
 			},
 			Category: category,
 		},
@@ -64,7 +65,7 @@ func DeprecatedCLIFlags(envPrefix, category string) []cli.Flag {
 			Action: func(_ *cli.Context, _ uint64) error {
 				return fmt.Errorf("flag --%s (env var %s) is deprecated, use --%s (env var %s) instead",
 					DeprecatedEthConfirmationDepthFlagName, withDeprecatedEnvPrefix(envPrefix, "ETH_CONFIRMATION_DEPTH"),
-					EthConfirmationDepthFlagName, withEnvPrefix(envPrefix, "ETH_CONFIRMATION_DEPTH"))
+					eigendaflags.ConfirmationDepthFlagName, withEnvPrefix(envPrefix, "CONFIRMATION_DEPTH"))
 			},
 			Category: category,
 		},


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #NNN` to link your PR with the
issue, replacing `#NNN` with the issue number you are fixing -->

This PR depends on https://github.com/Layr-Labs/eigenda/pull/821 being merged first.

Main simplification that this allows is getting rid of the very complex retry logic that we had where an inner functionw as returning an error that was being caught by a very outward for loop, which was hard to understand. This PR makes that logic more local, but I opted to still keep the check in eigenda-proxy as well as an assert/safety guarantee. Think we also need it in the Get route... but not super familiar with that code path cc @epociask to make sure logic in this PR still works for that.

## Fixes Issue

<!-- Example: Closes #NNN -->
Fixes #

## Changes proposed

<!-- List all the proposed changes in your PR -->
<!-- Add the screenshots of the changes below if applicable -->

### Screenshots (Optional)

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
