### PR TITLE
fix: Disable `SERVICE_MANAGER_ADDR` & `ETH_RPC` as mandatory

### DIFF
--- a/client/simple.go
+++ b/client/simple.go
@@ -15,7 +15,7 @@ type Config struct {
 
 // SimpleCommitmentClient implements a simple client for the eigenda-proxy
 // that can put/get simple commitment data and query the health endpoint.
-// It is meant to be used by arbitrum nitro integrations.
+// Currently it is meant to be used by Arbitrum nitro integrations but can be extended to others in the future.
 // Optimism has its own client: https://github.com/ethereum-optimism/optimism/blob/develop/op-alt-da/daclient.go
 // so clients wanting to send op commitment mode data should use that client.
 type SimpleCommitmentClient struct {

--- a/flags/eigendaflags/cli.go
+++ b/flags/eigendaflags/cli.go
@@ -144,14 +144,14 @@ func CLIFlags(envPrefix, category string) []cli.Flag {
 			Usage:    "URL of the Ethereum RPC endpoint. Needed to confirm blobs landed onchain.",
 			EnvVars:  []string{withEnvPrefix(envPrefix, "ETH_RPC")},
 			Category: category,
-			Required: true,
+			Required: false,
 		},
 		&cli.StringFlag{
 			Name:     SvcManagerAddrFlagName,
 			Usage:    "Address of the EigenDAServiceManager contract. Required to confirm blobs landed onchain. See https://github.com/Layr-Labs/eigenlayer-middleware/?tab=readme-ov-file#current-mainnet-deployment",
 			EnvVars:  []string{withEnvPrefix(envPrefix, "SERVICE_MANAGER_ADDR")},
 			Category: category,
-			Required: true,
+			Required: false,
 		},
 		// Flags that are proxy specific, and not used by the eigenda-client
 		// TODO: should we move this to a more specific category, like EIGENDA_STORE?

--- a/server/config.go
+++ b/server/config.go
@@ -45,6 +45,13 @@ func (cfg *Config) Check() error {
 		}
 	}
 
+	// provide dummy values to eigenda client config. Since the client won't be called in this
+	// mode it doesn't matter.
+	if cfg.MemstoreEnabled {
+		cfg.EdaClientConfig.SvcManagerAddr = "0x0000000000000000000000000000000000000000"
+		cfg.EdaClientConfig.EthRpcUrl = "http://0.0.0.0:666"
+	}
+
 	// cert verification is enabled
 	// TODO: move this verification logic to verify/cli.go
 	if cfg.VerifierConfig.VerifyCerts {

--- a/server/config.go
+++ b/server/config.go
@@ -47,9 +47,18 @@ func (cfg *Config) Check() error {
 
 	// provide dummy values to eigenda client config. Since the client won't be called in this
 	// mode it doesn't matter.
-	if cfg.MemstoreEnabled || !cfg.VerifierConfig.VerifyCerts {
+	if cfg.MemstoreEnabled {
 		cfg.EdaClientConfig.SvcManagerAddr = "0x0000000000000000000000000000000000000000"
 		cfg.EdaClientConfig.EthRpcUrl = "http://0.0.0.0:666"
+	}
+
+	if !cfg.MemstoreEnabled {
+		if cfg.EdaClientConfig.SvcManagerAddr == "" {
+			return fmt.Errorf("service manager address is required for communication with EigenDA")
+		}
+		if cfg.EdaClientConfig.EthRpcUrl == "" {
+			return fmt.Errorf("eth prc url is required for communication with EigenDA")
+		}
 	}
 
 	// cert verification is enabled

--- a/server/config.go
+++ b/server/config.go
@@ -47,7 +47,7 @@ func (cfg *Config) Check() error {
 
 	// provide dummy values to eigenda client config. Since the client won't be called in this
 	// mode it doesn't matter.
-	if cfg.MemstoreEnabled {
+	if cfg.MemstoreEnabled || !cfg.VerifierConfig.VerifyCerts {
 		cfg.EdaClientConfig.SvcManagerAddr = "0x0000000000000000000000000000000000000000"
 		cfg.EdaClientConfig.EthRpcUrl = "http://0.0.0.0:666"
 	}

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -90,8 +90,7 @@ func TestConfigVerification(t *testing.T) {
 			require.Error(t, err)
 		})
 
-		t.Run("EigenDAClientFieldsAreDefaultSetWhenCertVerifierDisabled", func(t *testing.T) {
-			// 1 - memstore
+		t.Run("EigenDAClientFieldsAreDefaultSetWhenMemStoreEnabled", func(t *testing.T) {
 			cfg := validCfg()
 			cfg.MemstoreEnabled = true
 			cfg.VerifierConfig.VerifyCerts = false
@@ -102,18 +101,16 @@ func TestConfigVerification(t *testing.T) {
 			require.NoError(t, err)
 			require.True(t, len(cfg.EdaClientConfig.EthRpcUrl) > 1)
 			require.True(t, len(cfg.EdaClientConfig.SvcManagerAddr) > 1)
+		})
 
-			// 2 - cert verification disabled
-			cfg = validCfg()
+		t.Run("FailWhenEigenDAClientFieldsAreUnsetAndMemStoreDisabled", func(t *testing.T) {
+			cfg := validCfg()
 			cfg.MemstoreEnabled = false
-			cfg.VerifierConfig.VerifyCerts = false
 			cfg.VerifierConfig.RPCURL = ""
 			cfg.VerifierConfig.SvcManagerAddr = ""
 
-			err = cfg.Check()
-			require.NoError(t, err)
-			require.True(t, len(cfg.EdaClientConfig.EthRpcUrl) > 1)
-			require.True(t, len(cfg.EdaClientConfig.SvcManagerAddr) > 1)
+			err := cfg.Check()
+			require.Error(t, err)
 		})
 	})
 

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -89,6 +89,32 @@ func TestConfigVerification(t *testing.T) {
 			err := cfg.Check()
 			require.Error(t, err)
 		})
+
+		t.Run("EigenDAClientFieldsAreDefaultSetWhenCertVerifierDisabled", func(t *testing.T) {
+			// 1 - memstore
+			cfg := validCfg()
+			cfg.MemstoreEnabled = true
+			cfg.VerifierConfig.VerifyCerts = false
+			cfg.VerifierConfig.RPCURL = ""
+			cfg.VerifierConfig.SvcManagerAddr = ""
+
+			err := cfg.Check()
+			require.NoError(t, err)
+			require.True(t, len(cfg.EdaClientConfig.EthRpcUrl) > 1)
+			require.True(t, len(cfg.EdaClientConfig.SvcManagerAddr) > 1)
+
+			// 2 - cert verification disabled
+			cfg = validCfg()
+			cfg.MemstoreEnabled = false
+			cfg.VerifierConfig.VerifyCerts = false
+			cfg.VerifierConfig.RPCURL = ""
+			cfg.VerifierConfig.SvcManagerAddr = ""
+
+			err = cfg.Check()
+			require.NoError(t, err)
+			require.True(t, len(cfg.EdaClientConfig.EthRpcUrl) > 1)
+			require.True(t, len(cfg.EdaClientConfig.SvcManagerAddr) > 1)
+		})
 	})
 
 }


### PR DESCRIPTION
## Changes proposed
Fixes a config processing bug where cert verification can be disabled but the application will crash since the service manager and eth rpc params are still required even-though they shouldn't be. 

Created https://github.com/Layr-Labs/eigenda-proxy/issues/206 to identify that there are better solutions.