### PR TITLE
fix: copy `client/go.mod` to `builder` in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /app
 
 # Copy go.mod and go.sum files
 COPY go.mod go.sum ./
+COPY client/go.mod ./client/
 
 # Download all dependencies. Dependencies will be cached if the go.mod and go.sum files are not changed
 RUN go mod download

--- a/Dockerfile.dockerignore
+++ b/Dockerfile.dockerignore
@@ -3,6 +3,7 @@
 
 # Re-include necessary files only
 !go.mod
+!client/go.mod
 !go.sum
 !*/**/*.go
 !Makefile


### PR DESCRIPTION
## Fixes Issue

When building the Dockerfile at the project's root, it fails because a `go.mod` file is missing.

## Changes proposed

Copy the missing `go.mod` file (`client/go.mod`) along with the root's `go.mod`. This requires adding the file to the `Dockerfile.dockerignore` as an exception.
