### PR TITLE
Fix single node tree verification bug

### DIFF
--- a/verify/merkle.go
+++ b/verify/merkle.go
@@ -7,9 +7,14 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
-// ProcessInclusionProof processes the Merkle root proof
+// ProcessInclusionProof computes the merkle root hash based on the provided leaf and proof, returning the result.
+// An error is returned if the proof param is malformed.
+//
+// NOTE: this method returning a nil error does NOT indicate that the proof is valid. Rather, it merely indicates that
+// the proof was well-formed. The hash returned by this method must be compared to the claimed root hash, to
+// determine if the proof is valid.
 func ProcessInclusionProof(proof []byte, leaf common.Hash, index uint64) (common.Hash, error) {
-	if len(proof) == 0 || len(proof)%32 != 0 {
+	if len(proof)%32 != 0 {
 		return common.Hash{}, errors.New("proof length should be a multiple of 32 bytes or 256 bits")
 	}
 

--- a/verify/merkle_test.go
+++ b/verify/merkle_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/wealdtech/go-merkletree/v2"
 	"github.com/wealdtech/go-merkletree/v2/keccak256"
 
@@ -48,19 +47,19 @@ func TestProcessInclusionProofFail(t *testing.T) {
 // TestProcessInclusionProofSingleNode confirms that a merkle tree containing a single node is successfully confirmed
 func TestProcessInclusionProofSingleNode(t *testing.T) {
 	leaf, err := hex.DecodeString("616C6C206861696C20746865206772656174207361746F736869")
-	assert.NotNil(t, leaf)
-	assert.NoError(t, err)
+	require.NotNil(t, leaf)
+	require.NoError(t, err)
 
 	tree, err := merkletree.NewTree(merkletree.WithData([][]byte{leaf}), merkletree.WithHashType(keccak256.New()))
-	assert.NotNil(t, tree)
+	require.NotNil(t, tree)
 	require.NoError(t, err)
 
 	merkleProof, err := tree.GenerateProofWithIndex(0, 0)
-	assert.NotNil(t, merkleProof)
+	require.NotNil(t, merkleProof)
 	require.NoError(t, err)
 
 	// sanity check: there shouldn't be any sibling hashes for this tree
-	assert.Equal(t, 0, len(merkleProof.Hashes))
+	require.Equal(t, 0, len(merkleProof.Hashes))
 
 	emptyProof := make([]byte, 0)
 
@@ -68,20 +67,20 @@ func TestProcessInclusionProofSingleNode(t *testing.T) {
 		emptyProof,
 		common.BytesToHash(keccak256.New().Hash(leaf)),
 		0)
-	assert.NotNil(t, computedRoot)
+	require.NotNil(t, computedRoot)
 	require.NoError(t, err)
-	assert.Equal(t, computedRoot.Bytes(), tree.Root())
+	require.Equal(t, computedRoot.Bytes(), tree.Root())
 
 	// create an alternate leaf, and make sure that the inclusion proof fails the comparison check
 	badLeaf, err := hex.DecodeString("ab")
-	assert.NotNil(t, badLeaf)
-	assert.NoError(t, err)
+	require.NotNil(t, badLeaf)
+	require.NoError(t, err)
 
 	computedRoot, err = ProcessInclusionProof(
 		emptyProof,
 		common.BytesToHash(keccak256.New().Hash(badLeaf)),
 		0)
-	assert.NotNil(t, computedRoot)
-	assert.NoError(t, err)
-	assert.NotEqual(t, computedRoot.Bytes(), tree.Root())
+	require.NotNil(t, computedRoot)
+	require.NoError(t, err)
+	require.NotEqual(t, computedRoot.Bytes(), tree.Root())
 }

--- a/verify/merkle_test.go
+++ b/verify/merkle_test.go
@@ -1,7 +1,6 @@
 package verify
 
 import (
-	"encoding/hex"
 	"testing"
 
 	"github.com/wealdtech/go-merkletree/v2"
@@ -46,7 +45,7 @@ func TestProcessInclusionProofFail(t *testing.T) {
 
 // TestProcessInclusionProofSingleNode confirms that a merkle tree containing a single node is successfully confirmed
 func TestProcessInclusionProofSingleNode(t *testing.T) {
-	leaf, err := hex.DecodeString("616C6C206861696C20746865206772656174207361746F736869")
+	leaf, err := hexutil.Decode("0x616C6C206861696C20746865206772656174207361746F736869")
 	require.NotNil(t, leaf)
 	require.NoError(t, err)
 
@@ -72,7 +71,7 @@ func TestProcessInclusionProofSingleNode(t *testing.T) {
 	require.Equal(t, computedRoot.Bytes(), tree.Root())
 
 	// create an alternate leaf, and make sure that the inclusion proof fails the comparison check
-	badLeaf, err := hex.DecodeString("ab")
+	badLeaf, err := hexutil.Decode("0xab")
 	require.NotNil(t, badLeaf)
 	require.NoError(t, err)
 


### PR DESCRIPTION
- Remove the incorrect invariant check, which would fail proof with 0 length
- Add unit test to confirm 0 length proofs can succeed verification
- closes https://github.com/Layr-Labs/eigenda-proxy/issues/215
