### PR TITLE
Fix single node tree verification bug

### DIFF
--- a/verify/merkle.go
+++ b/verify/merkle.go
@@ -7,9 +7,14 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
-// ProcessInclusionProof processes the Merkle root proof
+// ProcessInclusionProof computes the merkle root hash based on the provided leaf and proof, returning the result.
+// An error is returned if the proof param is malformed.
+//
+// NOTE: this method returning a nil error does NOT indicate that the proof is valid. Rather, it merely indicates that
+// the proof was well-formed. The hash returned by this method must be compared to the claimed root hash, to
+// determine if the proof is valid.
 func ProcessInclusionProof(proof []byte, leaf common.Hash, index uint64) (common.Hash, error) {
-	if len(proof) == 0 || len(proof)%32 != 0 {
+	if len(proof)%32 != 0 {
 		return common.Hash{}, errors.New("proof length should be a multiple of 32 bytes or 256 bits")
 	}
 

--- a/verify/merkle.go
+++ b/verify/merkle.go
@@ -10,6 +10,10 @@ import (
 // ProcessInclusionProof computes the merkle root hash based on the provided leaf and proof, returning the result.
 // An error is returned if the proof param is malformed.
 //
+// index is the index of the leaf in the tree, starting from the bottom left of the tree at 0.
+//
+// If the proof length is 0, then the leaf hash is returned.
+//
 // NOTE: this method returning a nil error does NOT indicate that the proof is valid. Rather, it merely indicates that
 // the proof was well-formed. The hash returned by this method must be compared to the claimed root hash, to
 // determine if the proof is valid.

--- a/verify/merkle.go
+++ b/verify/merkle.go
@@ -17,6 +17,9 @@ import (
 // NOTE: this method returning a nil error does NOT indicate that the proof is valid. Rather, it merely indicates that
 // the proof was well-formed. The hash returned by this method must be compared to the claimed root hash, to
 // determine if the proof is valid.
+//
+// This method is a reimplementation of the on-chain verification method [processInclusionProofKeccak]
+// (https://github.com/Layr-Labs/eigenlayer-contracts/blob/dev/src/contracts/libraries/Merkle.sol#L49-L76)
 func ProcessInclusionProof(proof []byte, leaf common.Hash, index uint64) (common.Hash, error) {
 	if len(proof)%32 != 0 {
 		return common.Hash{}, errors.New("proof length should be a multiple of 32 bytes or 256 bits")


### PR DESCRIPTION
- Remove the incorrect invariant check, which would fail proof with 0 length
- Add unit test to confirm 0 length proofs can succeed verification
- closes https://github.com/Layr-Labs/eigenda-proxy/issues/215