### PR TITLE
feat: add GET header to return raw blob

### DIFF
--- a/common/store.go
+++ b/common/store.go
@@ -69,6 +69,8 @@ type GeneratedKeyStore interface {
 	Store
 	// Get retrieves the given key if it's present in the key-value data store.
 	Get(ctx context.Context, key []byte) ([]byte, error)
+	// Get retrieves the given key if it's present in the key-value data store as the raw blob
+	GetRaw(ctx context.Context, key []byte) ([]byte, error)
 	// Put inserts the given value into the key-value data store.
 	Put(ctx context.Context, value []byte) (key []byte, err error)
 }
@@ -77,6 +79,8 @@ type PrecomputedKeyStore interface {
 	Store
 	// Get retrieves the given key if it's present in the key-value data store.
 	Get(ctx context.Context, key []byte) ([]byte, error)
+	// Get retrieves the given key if it's present in the key-value data store.
+	GetRaw(ctx context.Context, key []byte) ([]byte, error)
 	// Put inserts the given value into the key-value data store.
 	Put(ctx context.Context, key []byte, value []byte) error
 }

--- a/mocks/manager.go
+++ b/mocks/manager.go
@@ -44,6 +44,15 @@ func (m *MockIManager) Get(arg0 context.Context, arg1 []byte, arg2 commitments.C
 	return ret0, ret1
 }
 
+// Get mocks base method.
+func (m *MockIManager) GetRaw(arg0 context.Context, arg1 []byte, arg2 commitments.CommitmentMode) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRaw", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
 // Get indicates an expected call of Get.
 func (mr *MockIManagerMockRecorder) Get(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()

--- a/store/generated_key/eigenda/eigenda.go
+++ b/store/generated_key/eigenda/eigenda.go
@@ -67,6 +67,22 @@ func (e Store) Get(ctx context.Context, key []byte) ([]byte, error) {
 	return decodedBlob, nil
 }
 
+// ToDo still not correct impl
+func (e Store) GetRaw(ctx context.Context, key []byte) ([]byte, error) {
+	var cert verify.Certificate
+	err := rlp.DecodeBytes(key, &cert)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode DA cert to RLP format: %w", err)
+	}
+
+	decodedBlob, err := e.client.GetBlob(ctx, cert.BlobVerificationProof.BatchMetadata.BatchHeaderHash, cert.BlobVerificationProof.BlobIndex)
+	if err != nil {
+		return nil, fmt.Errorf("EigenDA client failed to retrieve decoded blob: %w", err)
+	}
+
+	return decodedBlob, nil
+}
+
 // Put disperses a blob for some pre-image and returns the associated RLP encoded certificate commit.
 func (e Store) Put(ctx context.Context, value []byte) ([]byte, error) {
 	encodedBlob, err := e.client.GetCodec().EncodeBlob(value)

--- a/store/precomputed_key/redis/redis.go
+++ b/store/precomputed_key/redis/redis.go
@@ -79,6 +79,10 @@ func (r *Store) Get(ctx context.Context, key []byte) ([]byte, error) {
 	return []byte(value), nil
 }
 
+func (r *Store) GetRaw(ctx context.Context, key []byte) ([]byte, error) {
+	return r.Get(ctx, key)
+}
+
 // Put ... inserts a value into the Redis store
 func (r *Store) Put(ctx context.Context, key []byte, value []byte) error {
 	return r.client.Set(ctx, string(key), string(value), r.eviction).Err()

--- a/store/precomputed_key/s3/s3.go
+++ b/store/precomputed_key/s3/s3.go
@@ -112,6 +112,10 @@ func (s *Store) Get(ctx context.Context, key []byte) ([]byte, error) {
 	return data, nil
 }
 
+func (s *Store) GetRaw(ctx context.Context, key []byte) ([]byte, error) {
+	return s.Get(ctx, key)
+}
+
 func (s *Store) Put(ctx context.Context, key []byte, value []byte) error {
 	_, err := s.client.PutObject(ctx, s.cfg.Bucket, path.Join(s.cfg.Path, hex.EncodeToString(key)), bytes.NewReader(value), int64(len(value)), s.putObjectOptions)
 	if err != nil {


### PR DESCRIPTION
This is a POC for returning raw codec-ed blob.

This POC is only tested against raw blob and other store getRaw isn't tested. 

This POC relies on http header on the http GET method to indicate if it wants the raw blob.

Recall suppose our blob is called A, the final output is IFFT(codec(A)).

The raw blob return you codec(A). An alternative way to reconstruct the header again inside the client code, which looks more verbose. 

This is only used for internal testing, the final approach is yet to be decided.