### PR TITLE
fix: memstore returns data_length in number of symbols instead of bytes

### DIFF
--- a/store/generated_key/memstore/memstore.go
+++ b/store/generated_key/memstore/memstore.go
@@ -169,7 +169,7 @@ func (e *MemStore) Put(_ context.Context, value []byte) ([]byte, error) {
 				X: commitment.X.Marshal(),
 				Y: commitment.Y.Marshal(),
 			},
-			DataLength: uint32( ( len(encodedVal) + BytesPerFieldElement - 1) / BytesPerFieldElement), // #nosec G115
+			DataLength: uint32((len(encodedVal) + BytesPerFieldElement - 1) / BytesPerFieldElement), // #nosec G115
 			BlobQuorumParams: []*disperser.BlobQuorumParam{
 				{
 					QuorumNumber:                    1,

--- a/store/generated_key/memstore/memstore.go
+++ b/store/generated_key/memstore/memstore.go
@@ -21,6 +21,7 @@ import (
 
 const (
 	DefaultPruneInterval = 500 * time.Millisecond
+	BYTSE_PER_FIELD_ELEMENT = 32
 )
 
 type Config struct {
@@ -168,7 +169,7 @@ func (e *MemStore) Put(_ context.Context, value []byte) ([]byte, error) {
 				X: commitment.X.Marshal(),
 				Y: commitment.Y.Marshal(),
 			},
-			DataLength: uint32(len(encodedVal)), // #nosec G115
+			DataLength: uint32( ( len(encodedVal) + BYTSE_PER_FIELD_ELEMENT - 1) / BYTSE_PER_FIELD_ELEMENT), // #nosec G115
 			BlobQuorumParams: []*disperser.BlobQuorumParam{
 				{
 					QuorumNumber:                    1,

--- a/store/generated_key/memstore/memstore.go
+++ b/store/generated_key/memstore/memstore.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	DefaultPruneInterval = 500 * time.Millisecond
-	BYTSE_PER_FIELD_ELEMENT = 32
+	BytesPerFieldElement = 32
 )
 
 type Config struct {
@@ -169,7 +169,7 @@ func (e *MemStore) Put(_ context.Context, value []byte) ([]byte, error) {
 				X: commitment.X.Marshal(),
 				Y: commitment.Y.Marshal(),
 			},
-			DataLength: uint32( ( len(encodedVal) + BYTSE_PER_FIELD_ELEMENT - 1) / BYTSE_PER_FIELD_ELEMENT), // #nosec G115
+			DataLength: uint32( ( len(encodedVal) + BytesPerFieldElement - 1) / BytesPerFieldElement), // #nosec G115
 			BlobQuorumParams: []*disperser.BlobQuorumParam{
 				{
 					QuorumNumber:                    1,


### PR DESCRIPTION
This PR addresses a bug in memstore Put route.

The data_length should have returned number of symbols as opposed to number of bytes.

