### PR TITLE
feat: add http routes and handlers to get/patch the memstore config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -71,8 +71,7 @@ linters-settings:
     blocked:
       # List of blocked modules.
       # Default: []
-      modules:
-        - 
+      modules: []
   govet:
     # Enable all analyzers.
     # Default: false
@@ -133,9 +132,8 @@ linters:
     - durationcheck # checks for two durations multiplied together
     - errname # checks that sentinel errors are prefixed with the Err and error types are suffixed with the Error
     - errorlint # finds code that will cause problems with the error wrapping scheme introduced in Go 1.13
-    - execinquery # checks query string in Query function which reads your Go src files and warning it finds
     - exhaustive # checks exhaustiveness of enum switch statements
-    - exportloopref # checks for pointers to enclosing loop variables
+    - copyloopvar # checks for pointers to enclosing loop variables
     - forbidigo # forbids identifiers
     - funlen # tool for detection of long functions
     - gocheckcompilerdirectives # validates go compiler directive comments (//go:)

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ LDFLAGSSTRING +=-X main.Date=$(BUILD_TIME)
 LDFLAGSSTRING +=-X main.Version=$(GIT_TAG)
 LDFLAGS := -ldflags "$(LDFLAGSSTRING)"
 
-E2EFUZZTEST = FUZZ=true go test ./e2e -fuzz -v -fuzztime=15m
+E2EFUZZTEST = FUZZ=true go test ./e2e -fuzz -v -fuzztime=5m
 
 .PHONY: eigenda-proxy
 eigenda-proxy:
@@ -23,7 +23,7 @@ docker-build:
 	@docker build -t ghcr.io/layr-labs/eigenda-proxy:dev .
 
 run-memstore-server:
-	./bin/eigenda-proxy --memstore.enabled --eigenda.cert-verification-disabled --eigenda.eth-rpc http://localhost:8545 --eigenda.svc-manager-addr 0x123 --metrics.enabled
+	./bin/eigenda-proxy --memstore.enabled --metrics.enabled
 
 disperse-test-blob:
 	curl -X POST -d my-blob-content http://127.0.0.1:3100/put/

--- a/e2e/setup.go
+++ b/e2e/setup.go
@@ -275,6 +275,7 @@ func CreateTestSuite(testSuiteCfg server.CLIConfig) (TestSuite, func()) {
 
 	log.Info("Starting proxy server...")
 	r := mux.NewRouter()
+	proxySvr.RegisterRoutes(r)
 	err = proxySvr.Start(r)
 	if err != nil {
 		panic(err)

--- a/e2e/setup.go
+++ b/e2e/setup.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Layr-Labs/eigenda-proxy/metrics"
 	"github.com/Layr-Labs/eigenda-proxy/server"
 	"github.com/Layr-Labs/eigenda-proxy/store"
-	"github.com/Layr-Labs/eigenda-proxy/store/generated_key/memstore"
+	"github.com/Layr-Labs/eigenda-proxy/store/generated_key/memstore/memconfig"
 	"github.com/Layr-Labs/eigenda-proxy/store/precomputed_key/redis"
 	"github.com/Layr-Labs/eigenda-proxy/store/precomputed_key/s3"
 	"github.com/Layr-Labs/eigenda-proxy/verify"
@@ -20,6 +20,7 @@ import (
 	"github.com/Layr-Labs/eigenda/encoding/kzg"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/gorilla/mux"
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
 	"golang.org/x/exp/rand"
@@ -207,11 +208,10 @@ func TestSuiteConfig(testCfg *Cfg) server.CLIConfig {
 			},
 		},
 		MemstoreEnabled: testCfg.UseMemory,
-		MemstoreConfig: memstore.Config{
+		MemstoreConfig: memconfig.NewSafeConfig(memconfig.Config{
 			BlobExpiration:   testCfg.Expiration,
 			MaxBlobSizeBytes: maxBlobLengthBytes,
-		},
-
+		}),
 		StorageConfig: store.Config{
 			AsyncPutWorkers: testCfg.WriteThreadCount,
 		},
@@ -274,7 +274,8 @@ func CreateTestSuite(testSuiteCfg server.CLIConfig) (TestSuite, func()) {
 	proxySvr := server.NewServer(host, 0, sm, log, m)
 
 	log.Info("Starting proxy server...")
-	err = proxySvr.Start()
+	r := mux.NewRouter()
+	err = proxySvr.Start(r)
 	if err != nil {
 		panic(err)
 	}

--- a/server/config.go
+++ b/server/config.go
@@ -9,13 +9,14 @@ import (
 	"github.com/Layr-Labs/eigenda-proxy/metrics"
 	"github.com/Layr-Labs/eigenda-proxy/store"
 	"github.com/Layr-Labs/eigenda-proxy/store/generated_key/memstore"
+	"github.com/Layr-Labs/eigenda-proxy/store/generated_key/memstore/memconfig"
 	"github.com/Layr-Labs/eigenda-proxy/verify"
 	"github.com/Layr-Labs/eigenda/api/clients"
 )
 
 type Config struct {
 	EdaClientConfig clients.EigenDAClientConfig
-	MemstoreConfig  memstore.Config
+	MemstoreConfig  *memconfig.SafeConfig
 	StorageConfig   store.Config
 	VerifierConfig  verify.Config
 	PutRetries      uint

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/Layr-Labs/eigenda-proxy/common"
-	"github.com/Layr-Labs/eigenda-proxy/store/generated_key/memstore"
+	"github.com/Layr-Labs/eigenda-proxy/store/generated_key/memstore/memconfig"
 	"github.com/Layr-Labs/eigenda-proxy/verify"
 	"github.com/Layr-Labs/eigenda/api/clients"
 	"github.com/Layr-Labs/eigenda/encoding/kzg"
@@ -42,9 +42,9 @@ func validCfg() *Config {
 			EthConfirmationDepth: 12,
 		},
 		MemstoreEnabled: true,
-		MemstoreConfig: memstore.Config{
+		MemstoreConfig: memconfig.NewSafeConfig(memconfig.Config{
 			BlobExpiration: 25 * time.Minute,
-		},
+		}),
 	}
 }
 

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -99,7 +99,7 @@ func TestHandlerGet(t *testing.T) {
 			r := mux.NewRouter()
 			// enable this logger to help debug tests
 			server := NewServer("localhost", 0, mockStorageMgr, testLogger, metrics.NoopMetrics)
-			server.registerRoutes(r)
+			server.RegisterRoutes(r)
 			r.ServeHTTP(rec, req)
 
 			require.Equal(t, tt.expectedCode, rec.Code)
@@ -170,7 +170,7 @@ func TestHandlerPutSuccess(t *testing.T) {
 			r := mux.NewRouter()
 			// enable this logger to help debug tests
 			server := NewServer("localhost", 0, mockStorageMgr, testLogger, metrics.NoopMetrics)
-			server.registerRoutes(r)
+			server.RegisterRoutes(r)
 			r.ServeHTTP(rec, req)
 
 			require.Equal(t, tt.expectedCode, rec.Code)
@@ -255,7 +255,7 @@ func TestHandlerPutErrors(t *testing.T) {
 				r := mux.NewRouter()
 				// enable this logger to help debug tests
 				server := NewServer("localhost", 0, mockStorageMgr, testLogger, metrics.NoopMetrics)
-				server.registerRoutes(r)
+				server.RegisterRoutes(r)
 				r.ServeHTTP(rec, req)
 
 				require.Equal(t, tt.expectedHTTPCode, rec.Code)

--- a/server/load_store.go
+++ b/server/load_store.go
@@ -85,12 +85,6 @@ func LoadStoreManager(ctx context.Context, cfg CLIConfig, log logging.Logger, m 
 		return nil, fmt.Errorf("failed to create verifier: %w", err)
 	}
 
-	if vCfg.VerifyCerts {
-		log.Info("Certificate verification with Ethereum enabled")
-	} else {
-		log.Warn("Verification disabled")
-	}
-
 	// create EigenDA backend store
 	var eigenDA common.GeneratedKeyStore
 	if cfg.EigenDAConfig.MemstoreEnabled {
@@ -109,7 +103,7 @@ func LoadStoreManager(ctx context.Context, cfg CLIConfig, log logging.Logger, m 
 			verifier,
 			log,
 			&eigenda.StoreConfig{
-				MaxBlobSizeBytes:     cfg.EigenDAConfig.MemstoreConfig.MaxBlobSizeBytes,
+				MaxBlobSizeBytes:     cfg.EigenDAConfig.MemstoreConfig.MaxBlobSizeBytes(),
 				EthConfirmationDepth: cfg.EigenDAConfig.VerifierConfig.EthConfirmationDepth,
 				StatusQueryTimeout:   cfg.EigenDAConfig.EdaClientConfig.StatusQueryTimeout,
 				PutRetries:           cfg.EigenDAConfig.PutRetries,

--- a/server/routing.go
+++ b/server/routing.go
@@ -14,7 +14,7 @@ const (
 	routingVarNameCommitTypeByteHex = "commit_type_byte_hex"
 )
 
-func (svr *Server) registerRoutes(r *mux.Router) {
+func (svr *Server) RegisterRoutes(r *mux.Router) {
 	subrouterGET := r.Methods("GET").PathPrefix("/get").Subrouter()
 	// std commitments (for nitro)
 	subrouterGET.HandleFunc("/"+

--- a/server/routing_test.go
+++ b/server/routing_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Layr-Labs/eigenda-proxy/metrics"
 	"github.com/Layr-Labs/eigenda-proxy/mocks"
 	"github.com/golang/mock/gomock"
+	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/require"
 )
 
@@ -21,7 +22,8 @@ func TestRouting(t *testing.T) {
 
 	m := metrics.NewMetrics("default")
 	server := NewServer("localhost", 8080, mockRouter, testLogger, m)
-	err := server.Start()
+	r := mux.NewRouter()
+	err := server.Start(r)
 	require.NoError(t, err)
 
 	tests := []struct {

--- a/server/server.go
+++ b/server/server.go
@@ -53,9 +53,7 @@ func NewServer(host string, port int, sm store.IManager, log logging.Logger,
 	}
 }
 
-func (svr *Server) Start() error {
-	r := mux.NewRouter()
-	svr.registerRoutes(r)
+func (svr *Server) Start(r *mux.Router) error {
 	svr.httpServer.Handler = r
 
 	listener, err := net.Listen("tcp", svr.endpoint)

--- a/store/generated_key/memstore/README.md
+++ b/store/generated_key/memstore/README.md
@@ -11,7 +11,7 @@ The Memstore backend is a simple in-memory key-value store that is meant to repl
 ## Configuration
 
 See [memconfig/config.go](./memconfig/config.go) for the configuration options.
-These can all be set via their respective flags or environment variables.
+These can all be set via their respective flags or environment variables. Run `./bin/eigenda-proxy --help | grep memstore` to see these.
 
 ## Config REST API
 

--- a/store/generated_key/memstore/README.md
+++ b/store/generated_key/memstore/README.md
@@ -1,0 +1,49 @@
+# Memstore Backend
+
+The Memstore backend is a simple in-memory key-value store that is meant to replace a real EigenDA backend (talking to the disperser) for testing and development purposes. It is not recommended for production use.
+
+## Usage
+
+```bash
+./bin/eigenda-proxy --memstore.enabled
+```
+
+## Configuration
+
+See [memconfig/config.go](./memconfig/config.go) for the configuration options.
+These can all be set via their respective flags or environment variables.
+
+## Config REST API
+
+The Memstore backend also provides a REST API for changing the configuration at runtime. This is useful for testing different configurations without restarting the proxy.
+
+The API consists of GET and PATCH methods on the `/memstore/config` resource.
+
+### Get the current configuration
+
+```bash
+$ curl http://localhost:3100/memstore/config | jq
+{
+  "MaxBlobSizeBytes": 16777216,
+  "BlobExpiration": "25m0s",
+  "PutLatency": "0s",
+  "GetLatency": "0s",
+  "PutReturnsFailoverError": false
+}
+```
+
+### Set a configuration option
+
+The PATCH request allows to patch the configuration. This allows only sending a subset of the configuration options. The other fields will be left intact.
+
+```bash
+$ curl -X PATCH http://localhost:3100/memstore/config -d '{"PutReturnsFailoverError": true}'
+{"MaxBlobSizeBytes":16777216,"BlobExpiration":"25m0s","PutLatency":"0s","GetLatency":"0s","PutReturnsFailoverError":true}
+```
+
+One can of course still build a jq pipe to produce the same result (although still using PATCH instead of PUT since that is the only method available):
+```bash
+$ curl http://localhost:3100/memstore/config | \
+  jq '.PutLatency = "5s" | .GetLatency = "2s"' | \
+  curl -X PATCH http://localhost:3100/memstore/config -d @-
+```

--- a/store/generated_key/memstore/README.md
+++ b/store/generated_key/memstore/README.md
@@ -1,6 +1,6 @@
 # Memstore Backend
 
-The Memstore backend is a simple in-memory key-value store that is meant to replace a real EigenDA backend (talking to the disperser) for testing and development purposes. It is not recommended for production use.
+The Memstore backend is a simple in-memory key-value store that is meant to replace a real EigenDA backend (talking to the disperser) for testing and development purposes. It is **never** recommended for production use.
 
 ## Usage
 

--- a/store/generated_key/memstore/cli.go
+++ b/store/generated_key/memstore/cli.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/Layr-Labs/eigenda-proxy/store/generated_key/memstore/memconfig"
 	"github.com/Layr-Labs/eigenda-proxy/verify"
 	"github.com/urfave/cli/v2"
 )
@@ -98,16 +99,17 @@ func CLIFlags(envPrefix, category string) []cli.Flag {
 	}
 }
 
-func ReadConfig(ctx *cli.Context) Config {
-	return Config{
-		// TODO: there has to be a better way to get MaxBlobLengthBytes
-		// right now we get it from the verifier cli, but there's probably a way to share flags more nicely?
-		// maybe use a duplicate but hidden flag in memstore category, and set it using the action by reading
-		// from the other flag?
-		MaxBlobSizeBytes:        verify.MaxBlobLengthBytes,
-		BlobExpiration:          ctx.Duration(ExpirationFlagName),
-		PutLatency:              ctx.Duration(PutLatencyFlagName),
-		GetLatency:              ctx.Duration(GetLatencyFlagName),
-		PutReturnsFailoverError: ctx.Bool(PutReturnsFailoverErrorFlagName),
-	}
+func ReadConfig(ctx *cli.Context) *memconfig.SafeConfig {
+	return memconfig.NewSafeConfig(
+		memconfig.Config{
+			// TODO: there has to be a better way to get MaxBlobLengthBytes
+			// right now we get it from the verifier cli, but there's probably a way to share flags more nicely?
+			// maybe use a duplicate but hidden flag in memstore category, and set it using the action by reading
+			// from the other flag?
+			MaxBlobSizeBytes:        verify.MaxBlobLengthBytes,
+			BlobExpiration:          ctx.Duration(ExpirationFlagName),
+			PutLatency:              ctx.Duration(PutLatencyFlagName),
+			GetLatency:              ctx.Duration(GetLatencyFlagName),
+			PutReturnsFailoverError: ctx.Bool(PutReturnsFailoverErrorFlagName),
+		})
 }

--- a/store/generated_key/memstore/memconfig/config.go
+++ b/store/generated_key/memstore/memconfig/config.go
@@ -27,11 +27,11 @@ type Config struct {
 // Patches are reads as ConfigUpdates instead to handle omitted fields.
 func (c Config) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
-		MaxBlobSizeBytes        uint64 `json:"MaxBlobSizeBytes"`
-		BlobExpiration          string `json:"BlobExpiration"`
-		PutLatency              string `json:"PutLatency"`
-		GetLatency              string `json:"GetLatency"`
-		PutReturnsFailoverError bool   `json:"PutReturnsFailoverError"`
+		MaxBlobSizeBytes        uint64
+		BlobExpiration          string
+		PutLatency              string
+		GetLatency              string
+		PutReturnsFailoverError bool
 	}{
 		MaxBlobSizeBytes:        c.MaxBlobSizeBytes,
 		BlobExpiration:          c.BlobExpiration.String(),

--- a/store/generated_key/memstore/memconfig/config.go
+++ b/store/generated_key/memstore/memconfig/config.go
@@ -49,6 +49,14 @@ type SafeConfig struct {
 	config Config
 }
 
+// Need this because we marshal the entire proxy config on startup
+// to log it, and private fields are not marshalled.
+func (sc *SafeConfig) MarshalJSON() ([]byte, error) {
+	sc.mu.RLock()
+	defer sc.mu.RUnlock()
+	return json.Marshal(sc.config)
+}
+
 func NewSafeConfig(config Config) *SafeConfig {
 	return &SafeConfig{
 		config: config,

--- a/store/generated_key/memstore/memconfig/config.go
+++ b/store/generated_key/memstore/memconfig/config.go
@@ -1,0 +1,123 @@
+package memconfig
+
+import (
+	"encoding/json"
+	"sync"
+	"time"
+)
+
+// Config contains properties that are used to configure the MemStore's behavior.
+type Config struct {
+	MaxBlobSizeBytes uint64
+	BlobExpiration   time.Duration
+	// artificial latency added for memstore backend to mimic eigenda's latency
+	PutLatency time.Duration
+	GetLatency time.Duration
+	// when true, put requests will return an errorFailover error,
+	// after sleeping PutLatency duration.
+	// This can be used to simulate eigenda being down.
+	PutReturnsFailoverError bool
+}
+
+// MarshalJSON implements custom JSON marshaling for Config.
+// This is needed because time.Duration is serialized to nanoseconds,
+// which is hard to read.
+// We only implement Marshal and not Unmarshal because this is only needed
+// for the GET /memstore/config endpoint, which only reads the configuration.
+// Patches are reads as ConfigUpdates instead to handle omitted fields.
+func (c Config) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		MaxBlobSizeBytes        uint64 `json:"MaxBlobSizeBytes"`
+		BlobExpiration          string `json:"BlobExpiration"`
+		PutLatency              string `json:"PutLatency"`
+		GetLatency              string `json:"GetLatency"`
+		PutReturnsFailoverError bool   `json:"PutReturnsFailoverError"`
+	}{
+		MaxBlobSizeBytes:        c.MaxBlobSizeBytes,
+		BlobExpiration:          c.BlobExpiration.String(),
+		PutLatency:              c.PutLatency.String(),
+		GetLatency:              c.GetLatency.String(),
+		PutReturnsFailoverError: c.PutReturnsFailoverError,
+	})
+}
+
+// SafeConfig handles thread-safe access to Config.
+// It is uses by MemStore to read configuration values.
+// and by the MemStore API to update configuration values.
+type SafeConfig struct {
+	mu     sync.RWMutex
+	config Config
+}
+
+func NewSafeConfig(config Config) *SafeConfig {
+	return &SafeConfig{
+		config: config,
+	}
+}
+
+func (sc *SafeConfig) LatencyPUTRoute() time.Duration {
+	sc.mu.RLock()
+	defer sc.mu.RUnlock()
+	return sc.config.PutLatency
+}
+func (sc *SafeConfig) SetLatencyPUTRoute(latency time.Duration) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	sc.config.PutLatency = latency
+}
+
+func (sc *SafeConfig) LatencyGETRoute() time.Duration {
+	sc.mu.RLock()
+	defer sc.mu.RUnlock()
+	return sc.config.GetLatency
+}
+func (sc *SafeConfig) SetLatencyGETRoute(latency time.Duration) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	sc.config.GetLatency = latency
+}
+
+func (sc *SafeConfig) PutReturnsFailoverError() bool {
+	sc.mu.RLock()
+	defer sc.mu.RUnlock()
+	return sc.config.PutReturnsFailoverError
+}
+func (sc *SafeConfig) SetPUTReturnsFailoverError(returnsFailoverError bool) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	sc.config.PutReturnsFailoverError = returnsFailoverError
+}
+
+func (sc *SafeConfig) BlobExpiration() time.Duration {
+	sc.mu.RLock()
+	defer sc.mu.RUnlock()
+	return sc.config.BlobExpiration
+}
+func (sc *SafeConfig) SetBlobExpiration(expiration time.Duration) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	sc.config.BlobExpiration = expiration
+}
+
+func (sc *SafeConfig) MaxBlobSizeBytes() uint64 {
+	sc.mu.RLock()
+	defer sc.mu.RUnlock()
+	return sc.config.MaxBlobSizeBytes
+}
+func (sc *SafeConfig) SetMaxBlobSizeBytes(maxBlobSizeBytes uint64) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	sc.config.MaxBlobSizeBytes = maxBlobSizeBytes
+}
+
+func (sc *SafeConfig) Config() Config {
+	sc.mu.RLock()
+	defer sc.mu.RUnlock()
+	return sc.config
+}
+
+func (sc *SafeConfig) Update(config Config) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	sc.config = config
+}

--- a/store/generated_key/memstore/memconfig/http_handlers.go
+++ b/store/generated_key/memstore/memconfig/http_handlers.go
@@ -1,0 +1,107 @@
+package memconfig
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/Layr-Labs/eigensdk-go/logging"
+	"github.com/gorilla/mux"
+)
+
+// JSON bodies received by the PATCH /memstore/config endpoint are deserialized into this struct,
+// which is then used to update the memstore configuration.
+type ConfigUpdate struct {
+	MaxBlobSizeBytes        *uint64 `json:"MaxBlobSizeBytes,omitempty"`
+	PutLatency              *string `json:"PutLatency,omitempty"`
+	GetLatency              *string `json:"GetLatency,omitempty"`
+	PutReturnsFailoverError *bool   `json:"PutReturnsFailoverError,omitempty"`
+	BlobExpiration          *string `json:"BlobExpiration,omitempty"`
+}
+
+// HandlerHTTP is an admin HandlerHTTP for GETting and PATCHing the memstore configuration.
+// It adds routes to the proxy's main router (to be served on same port as the main proxy routes):
+// - GET /memstore/config: returns the current memstore configuration
+// - PATCH /memstore/config: updates the memstore configuration
+type HandlerHTTP struct {
+	log        logging.Logger
+	safeConfig *SafeConfig
+}
+
+func NewHandlerHTTP(log logging.Logger, safeConfig *SafeConfig) HandlerHTTP {
+	return HandlerHTTP{
+		log:        log,
+		safeConfig: safeConfig,
+	}
+}
+
+func (api HandlerHTTP) RegisterMemstoreConfigHandlers(r *mux.Router) {
+	memstore := r.PathPrefix("/memstore").Subrouter()
+	memstore.HandleFunc("/config", api.handleGetConfig).Methods("GET")
+	memstore.HandleFunc("/config", api.handleUpdateConfig).Methods("PATCH")
+}
+
+// Returns the config of the memstore in json format.
+// TODO: we prob want to use out custom Duration type instead of time.Duration
+// since time.Duration serializes to nanoseconds, which is hard to read.
+func (api HandlerHTTP) handleGetConfig(w http.ResponseWriter, _ *http.Request) {
+	// Return the current configuration
+	err := json.NewEncoder(w).Encode(api.safeConfig.Config())
+	if err != nil {
+		api.log.Error("failed to encode config", "error", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func (api HandlerHTTP) handleUpdateConfig(w http.ResponseWriter, r *http.Request) {
+	var update ConfigUpdate
+	if err := json.NewDecoder(r.Body).Decode(&update); err != nil {
+		// TODO: wrap this error?
+		api.log.Info("received bad update memstore config update", "err", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Only update fields that were included in the request
+	if update.PutLatency != nil {
+		duration, err := time.ParseDuration(*update.PutLatency)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		api.safeConfig.SetLatencyPUTRoute(duration)
+	}
+
+	if update.GetLatency != nil {
+		duration, err := time.ParseDuration(*update.GetLatency)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		api.safeConfig.SetLatencyGETRoute(duration)
+	}
+
+	if update.PutReturnsFailoverError != nil {
+		api.safeConfig.SetPUTReturnsFailoverError(*update.PutReturnsFailoverError)
+	}
+
+	if update.MaxBlobSizeBytes != nil {
+		api.safeConfig.SetMaxBlobSizeBytes(*update.MaxBlobSizeBytes)
+	}
+
+	if update.BlobExpiration != nil {
+		duration, err := time.ParseDuration(*update.BlobExpiration)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		api.safeConfig.SetBlobExpiration(duration)
+	}
+
+	// Return the current configuration
+	err := json.NewEncoder(w).Encode(api.safeConfig.Config())
+	if err != nil {
+		api.log.Error("failed to encode config", "error", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}

--- a/store/generated_key/memstore/memconfig/http_handlers_test.go
+++ b/store/generated_key/memstore/memconfig/http_handlers_test.go
@@ -1,0 +1,199 @@
+package memconfig
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Layr-Labs/eigensdk-go/logging"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	testLogger = logging.NewTextSLogger(os.Stdout, &logging.SLoggerOptions{AddSource: true})
+)
+
+func setup(config Config) (*mux.Router, *SafeConfig) {
+	safeConfig := NewSafeConfig(config)
+	r := mux.NewRouter()
+	api := NewHandlerHTTP(testLogger, safeConfig)
+	api.RegisterMemstoreConfigHandlers(r)
+
+	return r, safeConfig
+}
+
+func TestHandlersHTTP_GetConfig(t *testing.T) {
+	tests := []struct {
+		name         string
+		inputConfig  Config
+		route        string
+		expectedCode int
+		expectError  bool
+	}{
+		{
+			name:         "empty config",
+			inputConfig:  Config{},
+			route:        "/memstore/config",
+			expectedCode: http.StatusOK,
+			expectError:  false,
+		},
+		{
+			name: "full config",
+			inputConfig: Config{
+				MaxBlobSizeBytes:        1024,
+				BlobExpiration:          1 * time.Hour,
+				PutLatency:              1 * time.Second,
+				GetLatency:              2 * time.Second,
+				PutReturnsFailoverError: true,
+			},
+			route:        "/memstore/config",
+			expectedCode: http.StatusOK,
+			expectError:  false,
+		},
+		{
+			name: "partially filled config",
+			inputConfig: Config{
+				BlobExpiration: 1 * time.Hour,
+				PutLatency:     1 * time.Second,
+			},
+			route:        "/memstore/config",
+			expectedCode: http.StatusOK,
+			expectError:  false,
+		},
+		{
+			name:         "invalid route",
+			inputConfig:  Config{},
+			route:        "/memstore/config/",
+			expectedCode: http.StatusNotFound,
+			expectError:  true,
+		},
+		{
+			name:         "invalid route",
+			inputConfig:  Config{},
+			route:        "/memstore",
+			expectedCode: http.StatusNotFound,
+			expectError:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router, safeConfig := setup(tt.inputConfig)
+
+			req := httptest.NewRequest(http.MethodGet, tt.route, nil)
+			rec := httptest.NewRecorder()
+
+			router.ServeHTTP(rec, req)
+
+			require.Equal(t, tt.expectedCode, rec.Code)
+
+			var response Config
+			err := json.NewDecoder(rec.Body).Decode(&response)
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			expectedConfig := safeConfig.Config()
+			require.Equal(t, expectedConfig, response)
+		})
+	}
+}
+
+func TestHandlersHTTP_PatchConfig(t *testing.T) {
+	tests := []struct {
+		name            string
+		initialConfig   Config
+		requestBodyJSON string
+		expectedStatus  int
+		validate        func(*testing.T, Config, *SafeConfig)
+	}{
+		{
+			name: "update single field",
+			initialConfig: Config{
+				PutLatency: 2 * time.Second,
+				GetLatency: 2 * time.Second,
+			},
+			requestBodyJSON: `{"PutLatency": "5s"}`,
+			expectedStatus:  http.StatusOK,
+			validate: func(t *testing.T, inputConfig Config, sc *SafeConfig) {
+				outputConfig := sc.Config()
+				inputConfig.PutLatency = 5 * time.Second
+				require.Equal(t, inputConfig, outputConfig)
+			},
+		},
+		{
+			name: "invalid PutLatency value (not string) does not update config",
+			initialConfig: Config{
+				PutLatency: 1 * time.Second,
+			},
+			requestBodyJSON: `{"PutLatency": 1000}`,
+			expectedStatus:  http.StatusBadRequest,
+			validate: func(t *testing.T, inputConfig Config, sc *SafeConfig) {
+				outputConfig := sc.Config()
+				require.Equal(t, inputConfig, outputConfig)
+			},
+		},
+		{
+			name: "update multiple fields",
+			initialConfig: Config{
+				MaxBlobSizeBytes:        1024,
+				BlobExpiration:          1 * time.Hour,
+				PutLatency:              1 * time.Nanosecond,
+				GetLatency:              1 * time.Nanosecond,
+				PutReturnsFailoverError: true,
+			},
+			requestBodyJSON: `{"PutLatency": "5s", "GetLatency": "10s"}`,
+			expectedStatus:  http.StatusOK,
+			validate: func(t *testing.T, inputConfig Config, sc *SafeConfig) {
+				inputConfig.PutLatency = 5 * time.Second
+				inputConfig.GetLatency = 10 * time.Second
+				outputConfig := sc.Config()
+				require.Equal(t, inputConfig, outputConfig)
+			},
+		},
+		{
+			name:          "update all fields",
+			initialConfig: Config{},
+			requestBodyJSON: `{
+				"MaxBlobSizeBytes": 1024,
+				"BlobExpiration": "1h",
+				"PutLatency": "1s",
+				"GetLatency": "2s",
+				"PutReturnsFailoverError": true
+			}`,
+			expectedStatus: http.StatusOK,
+			validate: func(t *testing.T, inputConfig Config, sc *SafeConfig) {
+				outputConfig := sc.Config()
+				inputConfig.MaxBlobSizeBytes = 1024
+				inputConfig.BlobExpiration = 1 * time.Hour
+				inputConfig.PutLatency = 1 * time.Second
+				inputConfig.GetLatency = 2 * time.Second
+				inputConfig.PutReturnsFailoverError = true
+				require.Equal(t, inputConfig, outputConfig)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router, safeConfig := setup(tt.initialConfig)
+
+			req := httptest.NewRequest(http.MethodPatch, "/memstore/config", bytes.NewReader([]byte(tt.requestBodyJSON)))
+			rec := httptest.NewRecorder()
+
+			router.ServeHTTP(rec, req)
+
+			require.Equal(t, tt.expectedStatus, rec.Code)
+			if tt.validate != nil {
+				tt.validate(t, tt.initialConfig, safeConfig)
+			}
+		})
+	}
+}

--- a/store/generated_key/memstore/memconfig/http_handlers_test.go
+++ b/store/generated_key/memstore/memconfig/http_handlers_test.go
@@ -2,7 +2,6 @@ package memconfig
 
 import (
 	"bytes"
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -91,17 +90,14 @@ func TestHandlersHTTP_GetConfig(t *testing.T) {
 			router.ServeHTTP(rec, req)
 
 			require.Equal(t, tt.expectedCode, rec.Code)
-
-			var response Config
-			err := json.NewDecoder(rec.Body).Decode(&response)
 			if tt.expectError {
-				require.Error(t, err)
 				return
 			}
 
+			expectedResp, err := safeConfig.Config().MarshalJSON()
 			require.NoError(t, err)
-			expectedConfig := safeConfig.Config()
-			require.Equal(t, expectedConfig, response)
+			resp := rec.Body.String()
+			require.Equal(t, string(expectedResp) + "\n", resp)
 		})
 	}
 }

--- a/store/generated_key/memstore/memconfig/http_handlers_test.go
+++ b/store/generated_key/memstore/memconfig/http_handlers_test.go
@@ -97,7 +97,7 @@ func TestHandlersHTTP_GetConfig(t *testing.T) {
 			expectedResp, err := safeConfig.Config().MarshalJSON()
 			require.NoError(t, err)
 			resp := rec.Body.String()
-			require.Equal(t, string(expectedResp) + "\n", resp)
+			require.Equal(t, string(expectedResp)+"\n", resp)
 		})
 	}
 }

--- a/store/generated_key/memstore/memstore_test.go
+++ b/store/generated_key/memstore/memstore_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Layr-Labs/eigenda-proxy/store/generated_key/memstore/memconfig"
 	"github.com/Layr-Labs/eigenda-proxy/verify"
 	"github.com/Layr-Labs/eigenda/api"
 	"github.com/Layr-Labs/eigenda/encoding/kzg"
@@ -22,13 +23,13 @@ const (
 	testPreimage = "Four score and seven years ago"
 )
 
-func getDefaultMemStoreTestConfig() Config {
-	return Config{
+func getDefaultMemStoreTestConfig() *memconfig.SafeConfig {
+	return memconfig.NewSafeConfig(memconfig.Config{
 		MaxBlobSizeBytes: 1024 * 1024,
 		BlobExpiration:   0,
 		PutLatency:       0,
 		GetLatency:       0,
-	}
+	})
 }
 
 func getDefaultVerifierTestConfig() *verify.Config {
@@ -80,7 +81,7 @@ func TestExpiration(t *testing.T) {
 	require.NoError(t, err)
 
 	memstoreConfig := getDefaultMemStoreTestConfig()
-	memstoreConfig.BlobExpiration = 10 * time.Millisecond
+	memstoreConfig.SetBlobExpiration(10 * time.Millisecond)
 	ms, err := New(
 		ctx,
 		verifier,
@@ -115,8 +116,8 @@ func TestLatency(t *testing.T) {
 	require.NoError(t, err)
 
 	config := getDefaultMemStoreTestConfig()
-	config.PutLatency = putLatency
-	config.GetLatency = getLatency
+	config.SetLatencyPUTRoute(putLatency)
+	config.SetLatencyGETRoute(getLatency)
 	ms, err := New(ctx, verifier, testLogger, config)
 
 	require.NoError(t, err)
@@ -150,7 +151,7 @@ func TestPutRetursFailoverErrorConfig(t *testing.T) {
 	validKey, err := ms.Put(ctx, []byte("some-value"))
 	require.NoError(t, err)
 
-	ms.config.PutReturnsFailoverError = true
+	ms.config.SetPUTReturnsFailoverError(true)
 
 	// failover mode should only affect Put route
 	_, err = ms.Get(ctx, validKey)

--- a/verify/cert.go
+++ b/verify/cert.go
@@ -46,7 +46,6 @@ func NewCertVerifier(cfg *Config, log logging.Logger) (*CertVerifier, error) {
 		// We keep this low (<128) to avoid requiring an archive node.
 		return nil, fmt.Errorf("confirmation depth must be less than 64; consider using cfg.WaitForFinalization=true instead")
 	}
-	log.Info("Enabling certificate verification", "confirmation_depth", cfg.EthConfirmationDepth)
 
 	client, err := ethclient.Dial(cfg.RPCURL)
 	if err != nil {

--- a/verify/verifier.go
+++ b/verify/verifier.go
@@ -61,10 +61,13 @@ func NewVerifier(cfg *Config, l logging.Logger) (*Verifier, error) {
 	var err error
 
 	if cfg.VerifyCerts {
+		log.Info("Certificate verification against Ethereum state enabled")
 		cv, err = NewCertVerifier(cfg, l)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create cert verifier: %w", err)
 		}
+	} else {
+		log.Warn("Certificate verification against Ethereum state disabled")
 	}
 
 	kzgVerifier, err := kzgverifier.NewVerifier(cfg.KzgConfig, encoding.DefaultConfig())

--- a/verify/verifier.go
+++ b/verify/verifier.go
@@ -61,15 +61,16 @@ func NewVerifier(cfg *Config, l logging.Logger) (*Verifier, error) {
 	var err error
 
 	if cfg.VerifyCerts {
-		log.Info("Certificate verification against Ethereum state enabled")
 		cv, err = NewCertVerifier(cfg, l)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create cert verifier: %w", err)
 		}
+		log.Info("Certificate verification against Ethereum state enabled", "confirmation_depth", cfg.EthConfirmationDepth)
 	} else {
 		log.Warn("Certificate verification against Ethereum state disabled")
 	}
 
+	log.Info("Creating blob KZG verifier")
 	kzgVerifier, err := kzgverifier.NewVerifier(cfg.KzgConfig, encoding.DefaultConfig())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create kzg verifier: %w", err)


### PR DESCRIPTION
This is needed to create API-driven tests on the kurtosis devnet in our [op fork](https://github.com/Layr-Labs/optimism).

See the new memstore README for details of the REST API.

<!-- If your PR fixes an open issue, use `Closes #NNN` to link your PR with the
issue, replacing `#NNN` with the issue number you are fixing -->

## Fixes Issue

<!-- Example: Closes #NNN -->
Fixes #

## Changes proposed

<!-- List all the proposed changes in your PR -->
<!-- Add the screenshots of the changes below if applicable -->

### Screenshots (Optional)

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
