### PR TITLE
Rework v2 initialization

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -14,13 +14,13 @@ var (
 )
 
 type V2ClientConfig struct {
-	Enabled               bool
-	DisperserClientCfg    clients_v2.DisperserClientConfig
-	PayloadClientCfg      clients_v2.PayloadDisperserConfig
-	RetrievalConfig       clients_v2.RelayPayloadRetrieverConfig
-	ServiceManagerAddress string
-	EthRPC                string
-	PutRetries            uint
+	Enabled                  bool
+	DisperserClientCfg       clients_v2.DisperserClientConfig
+	PayloadDisperserCfg      clients_v2.PayloadDisperserConfig
+	RelayPayloadRetrieverCfg clients_v2.RelayPayloadRetrieverConfig
+	ServiceManagerAddress    string
+	EthRPC                   string
+	PutRetries               uint
 }
 
 func (cfg *V2ClientConfig) Check() error {
@@ -32,7 +32,7 @@ func (cfg *V2ClientConfig) Check() error {
 		return fmt.Errorf("eth rpc is required for using EigenDA V2 backend")
 	}
 
-	if cfg.PayloadClientCfg.SignerPaymentKey == "" {
+	if cfg.PayloadDisperserCfg.SignerPaymentKey == "" {
 		return fmt.Errorf("signer payment private key hex is required for using EigenDA V2 backend")
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -56,7 +56,7 @@ func validCfg() *ProxyConfig {
 				Port:              "9999",
 				UseSecureGrpcFlag: true,
 			},
-			PayloadClientCfg: v2_clients.PayloadDisperserConfig{
+			PayloadDisperserCfg: v2_clients.PayloadDisperserConfig{
 				SignerPaymentKey: "0x000000000000000",
 			},
 			ServiceManagerAddress: "0x1234567890abcdef",
@@ -151,7 +151,7 @@ func TestConfigVerification(t *testing.T) {
 					require.Error(t, cfg.Check())
 
 					cfg = validCfg()
-					cfg.EdaV2ClientConfig.PayloadClientCfg.SignerPaymentKey = ""
+					cfg.EdaV2ClientConfig.PayloadDisperserCfg.SignerPaymentKey = ""
 					require.Error(t, cfg.Check())
 				})
 		})

--- a/config/eigendaflags/v2/cli.go
+++ b/config/eigendaflags/v2/cli.go
@@ -190,11 +190,11 @@ func ReadConfig(ctx *cli.Context) common.V2ClientConfig {
 		Enabled:               ctx.Bool(V2EnabledFlagName),
 		ServiceManagerAddress: ctx.String(SvcManagerAddrFlagName),
 
-		DisperserClientCfg: readDisperserCfg(ctx),
-		PayloadClientCfg:   readPayloadDisperserCfg(ctx),
-		RetrievalConfig:    readRetrievalConfig(ctx),
-		EthRPC:             ctx.String(EthRPCURLFlagName),
-		PutRetries:         ctx.Uint(PutRetriesFlagName),
+		DisperserClientCfg:       readDisperserCfg(ctx),
+		PayloadDisperserCfg:      readPayloadDisperserCfg(ctx),
+		RelayPayloadRetrieverCfg: readRetrievalConfig(ctx),
+		EthRPC:                   ctx.String(EthRPCURLFlagName),
+		PutRetries:               ctx.Uint(PutRetriesFlagName),
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.22.7
 
 require (
-	github.com/Layr-Labs/eigenda v0.9.0-rc.0.0.20250226193705-a0bee29e9337
+	github.com/Layr-Labs/eigenda v0.9.0-rc.0.0.20250228073203-6b470126ae4d
 	github.com/Layr-Labs/eigenda-proxy/clients v0.0.0-00010101000000-000000000000
 	github.com/Layr-Labs/eigensdk-go v0.2.0-beta.1.0.20250118004418-2a25f31b3b28
 	github.com/avast/retry-go/v4 v4.6.0

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,9 @@ github.com/Layr-Labs/eigenda v0.9.0-rc.0 h1:GXc9EiJcP+kJy/4h/O83oDPpGGE3GV2dPDwT
 github.com/Layr-Labs/eigenda v0.9.0-rc.0/go.mod h1:MO3EyBXCmhzttrmmgqmIkzDg4gtqWjU+0fxSN0Q1EmM=
 github.com/Layr-Labs/eigenda v0.9.0-rc.0.0.20250226193705-a0bee29e9337 h1:eiW5jJfjVxuvsqWE9vSaju5Y6Iu6nu3La8rf0PVoS2E=
 github.com/Layr-Labs/eigenda v0.9.0-rc.0.0.20250226193705-a0bee29e9337/go.mod h1:MO3EyBXCmhzttrmmgqmIkzDg4gtqWjU+0fxSN0Q1EmM=
+github.com/Layr-Labs/eigenda v0.9.0-rc.0.0.20250226230418-25c2e09756b5/go.mod h1:MO3EyBXCmhzttrmmgqmIkzDg4gtqWjU+0fxSN0Q1EmM=
+github.com/Layr-Labs/eigenda v0.9.0-rc.0.0.20250228073203-6b470126ae4d h1:8kmrCrKu8S3vqGhVuJWYVF1nwt5+sHKk0ewQqjDhaCE=
+github.com/Layr-Labs/eigenda v0.9.0-rc.0.0.20250228073203-6b470126ae4d/go.mod h1:MO3EyBXCmhzttrmmgqmIkzDg4gtqWjU+0fxSN0Q1EmM=
 github.com/Layr-Labs/eigensdk-go v0.2.0-beta.1.0.20250118004418-2a25f31b3b28 h1:Wig5FBBizIB5Z/ZcXJlm7KdOLnrXc6E3DjO63uWRzQM=
 github.com/Layr-Labs/eigensdk-go v0.2.0-beta.1.0.20250118004418-2a25f31b3b28/go.mod h1:YNzORpoebdDNv0sJLm/H9LTx72M85zA54eBSXI5DULw=
 github.com/Layr-Labs/eigensdk-go/signer v0.0.0-20250118004418-2a25f31b3b28 h1:rhIC2XpFpCcRkv4QYczIUe/fXvE4T+0B1mF9f6NJCuo=

--- a/store/builder.go
+++ b/store/builder.go
@@ -140,7 +140,7 @@ func (d *Builder) buildEigenDAV1Backend(
 	maxBlobSize uint) (common.GeneratedKeyStore, error) {
 	verifier, err := verify.NewVerifier(&d.v1VerifierCfg, d.log)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create verifier: %w", err)
+		return nil, fmt.Errorf("new verifier: %w", err)
 	}
 
 	if d.v1VerifierCfg.VerifyCerts {
@@ -274,7 +274,7 @@ func (d *Builder) buildRelayPayloadRetriever(
 		relayClient,
 		g1Srs)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create relay payload retriever: %w", err)
+		return nil, fmt.Errorf("new relay payload retriever: %w", err)
 	}
 
 	return relayPayloadRetriever, nil
@@ -302,7 +302,7 @@ func (d *Builder) buildRelayClient(
 
 	relayClient, err := clients_v2.NewRelayClient(relayCfg, d.log, relayURLProvider)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create relay client: %w", err)
+		return nil, fmt.Errorf("new relay client: %w", err)
 	}
 
 	return relayClient, nil

--- a/store/builder.go
+++ b/store/builder.go
@@ -20,7 +20,7 @@ import (
 	clients_v2 "github.com/Layr-Labs/eigenda/api/clients/v2"
 	"github.com/Layr-Labs/eigenda/api/clients/v2/relay"
 	"github.com/Layr-Labs/eigenda/api/clients/v2/verification"
-	common_da "github.com/Layr-Labs/eigenda/common"
+	common_eigenda "github.com/Layr-Labs/eigenda/common"
 	"github.com/Layr-Labs/eigenda/common/geth"
 	auth "github.com/Layr-Labs/eigenda/core/auth/v2"
 	eigenda_eth "github.com/Layr-Labs/eigenda/core/eth"
@@ -243,7 +243,7 @@ func (d *Builder) BuildManager(
 	return NewManager(eigenDAV1Store, eigenDAV2Store, s3Store, d.log, secondary, d.v2ClientCfg.Enabled)
 }
 
-func (d *Builder) buildEthClient() (common_da.EthClient, error) {
+func (d *Builder) buildEthClient() (common_eigenda.EthClient, error) {
 	gethCfg := geth.EthClientConfig{
 		RPCURLs: []string{d.v1EdaClientCfg.EthRpcUrl},
 	}
@@ -257,7 +257,7 @@ func (d *Builder) buildEthClient() (common_da.EthClient, error) {
 }
 
 func (d *Builder) buildRelayPayloadRetriever(
-	ethClient common_da.EthClient,
+	ethClient common_eigenda.EthClient,
 	maxBlobSizeBytes uint,
 	g1Srs []bn254.G1Affine,
 ) (*clients_v2.RelayPayloadRetriever, error) {
@@ -281,7 +281,7 @@ func (d *Builder) buildRelayPayloadRetriever(
 }
 
 func (d *Builder) buildRelayClient(
-	ethClient common_da.EthClient,
+	ethClient common_eigenda.EthClient,
 	maxBlobSizeBytes uint) (clients_v2.RelayClient, error) {
 	reader, err := eigenda_eth.NewReader(d.log, ethClient, "0x0", d.v2ClientCfg.ServiceManagerAddress)
 	if err != nil {


### PR DESCRIPTION
- This PR reworks how v2 initialization is done
    - it moves builder logic into helper methods, and uses basic constructors instead of the builders defined in the core repo. IMO it makes sense for proxy to define these builders, and the base classes should just have constructors which accept complete subcomponents
- closes https://github.com/Layr-Labs/eigenda-proxy/issues/272 (e2e tests now pass with client side proving enabled)
