### PR TITLE
fix: Enforce V1 cert field sizes

### DIFF
--- a/store/generated_key/eigenda/eigenda.go
+++ b/store/generated_key/eigenda/eigenda.go
@@ -136,7 +136,12 @@ func (e Store) Put(ctx context.Context, value []byte) ([]byte, error) {
 
 	err = cert.NoNilFields()
 	if err != nil {
-		return nil, fmt.Errorf("failed to verify DA cert: %w", err)
+		return nil, fmt.Errorf("failed to verify DA cert due to nil fields: %w", err)
+	}
+
+	err = cert.ValidFieldLengths()
+	if err != nil {
+		return nil, fmt.Errorf("failed to verify DA cert due to invalid field lenghts: %w", err)
 	}
 
 	err = e.verifier.VerifyCommitment(cert.BlobHeader.GetCommitment(), encodedBlob)

--- a/store/generated_key/eigenda/eigenda.go
+++ b/store/generated_key/eigenda/eigenda.go
@@ -141,7 +141,7 @@ func (e Store) Put(ctx context.Context, value []byte) ([]byte, error) {
 
 	err = cert.ValidFieldLengths()
 	if err != nil {
-		return nil, fmt.Errorf("failed to verify DA cert due to invalid field lenghts: %w", err)
+		return nil, fmt.Errorf("failed to verify DA cert due to invalid field lengths: %w", err)
 	}
 
 	err = e.verifier.VerifyCommitment(cert.BlobHeader.GetCommitment(), encodedBlob)

--- a/verify/v1/certificate.go
+++ b/verify/v1/certificate.go
@@ -56,6 +56,48 @@ func (c *Certificate) NoNilFields() error {
 	return nil
 }
 
+// ValidFieldLengths ... enforces length invariance on certificate fields which are expected
+// to be size constrained but are read as unfixed byte arrays from the disperser.
+// This is necessary to remove a trust assumption and grieving vector where the
+// disperser can intentionally increase the data sizes and cause a rollup to incur higher
+// operating costs when publishing certificates to some batcher inbox
+func (c *Certificate) ValidFieldLengths() error {
+	bvp := c.BlobVerificationProof
+	bh := c.BlobHeader
+
+	// 1 - necessary invariants to remove disperser trust assumption
+
+	// 1.a necessary since only first 32 bytes of header hash are checked
+	//     in verification equivalence check which could allow data padding at end
+	if hashLen := len(bvp.BatchMetadata.BatchHeaderHash); hashLen != 32 {
+		return fmt.Errorf("BlobVerification.BatchMetadata.BatchHeaderHash is not 32 bytes, got %d", hashLen)
+	}
+
+	// 1.b necessary since commitment verification parses the byte field byte arrays
+	//     into a field element representation which disregards 0x0 padded bytes
+	if xLen := len(bh.Commitment.X); xLen != 32 {
+		return fmt.Errorf("BlobHeader.Commitment.X is not 32 bytes, got %d", xLen)
+	}
+
+	if yLen := len(bh.Commitment.Y); yLen != 32 {
+		return fmt.Errorf("BlobHeader.Commitment.Y is not 32 bytes, got %d", yLen)
+	}
+
+	// 2 - unnecessary but preemptive checks that would trigger failure in downstream
+	//     verification since these values are used as input for batch metadata hash
+	//     recomputation. Capturing here is more efficient!
+
+	if hashLen := len(bvp.BatchMetadata.SignatoryRecordHash); hashLen != 32 {
+		return fmt.Errorf("BlobVerification.BatchMetadata.SignatoryRecordHash is not 32 bytes, got %d", hashLen)
+	}
+
+	if hashLen := len(bvp.BatchMetadata.BatchHeader.BatchRoot); hashLen != 32 {
+		return fmt.Errorf("BlobVerification.BatchMetadata.BatchHeader.BatchRoot is not 32 bytes, got %d", hashLen)
+	}
+
+	return nil
+}
+
 func (c *Certificate) BlobIndex() uint32 {
 	return c.BlobVerificationProof.BlobIndex
 }


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #NNN` to link your PR with the
issue, replacing `#NNN` with the issue number you are fixing -->

## Fixes Issue

<!-- Example: Closes #NNN -->
Fixes #

## Changes proposed
Mitigates risk where the disperser can increase the size of dynamic array fields to be larger than their expected size limit with verification still passing. If performed, the disperser could:
1. Overload DA commitment sizes used for batcher inbox submissions on OP x EigenDA rollups to grief
2. Break secondary storage on Arbitrum x EigenDA rollups by providing a cert that can't be regenerated perfectly when doing get queries when deriving L2 state from the sequencer inbox 

Having this size enforcement also securely enables https://github.com/Layr-Labs/nitro/pull/76 

### Screenshots (Optional)

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
