### PR TITLE
test(fuzz): fix fuzz tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,9 +42,11 @@ test-e2e-holesky:
 	# Good to have early feedback when needed.
 	MEMSTORE=false go test -v -timeout 10m ./e2e -parallel 4
 
-# E2E test which fuzzes the proxy client server integration and op client keccak256 with malformed inputs
+# Very simple fuzzer which generates random bytes arrays and sends them to the proxy using the standard client.
+# To clean the cached corpus, run `go clean -fuzzcache` before running this.
 test-fuzz:
-	go test ./fuzz -fuzz -v -fuzztime=5m
+	go test ./fuzz -fuzz=FuzzProxyClientServerV1 -fuzztime=1m
+	go test ./fuzz -fuzz=FuzzProxyClientServerV2 -fuzztime=1m
 
 .PHONY: lint
 lint:


### PR DESCRIPTION
Cleaned up the fuzz tests to actually do something Reduced seed corpus to 3 meaningful inputs
Removed cluttering log outputs so we can actually see the fuzzer output as its finding new interesting cases
Here's an output of running `make test-fuzz`:
![image](https://github.com/user-attachments/assets/9306d723-90e5-4f95-9f43-6789fa7ac63b)


<!-- If your PR fixes an open issue, use `Closes #NNN` to link your PR with the
issue, replacing `#NNN` with the issue number you are fixing -->

## Fixes Issue

<!-- Example: Closes #NNN -->
Fixes #

## Changes proposed

<!-- List all the proposed changes in your PR -->
<!-- Add the screenshots of the changes below if applicable -->

### Screenshots (Optional)

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
