### PR TITLE
Get preprod CI passing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,14 +38,14 @@ test-e2e-local:
 # E2E tests using holesky testnet backend, leveraging op-e2e framework. Also tests the standard client against the proxy.
 # If holesky tests are failing, consider checking https://dora.holesky.ethpandaops.io/epochs for block production status.
 test-e2e-testnet:
-	# Add the -v flag to observe logs as the run is happening on CI, given that this test takes ~40 minutes to run.
+	# Add the -v flag to observe logs as the run is happening on CI, given that this test takes ~20 minutes to run.
 	# Good to have early feedback when needed.
-	BACKEND=testnet go test -v -timeout 60m ./e2e -parallel 4
+	BACKEND=testnet go test -v -timeout 30m ./e2e -parallel 8
 
 test-e2e-preprod:
-	# Add the -v flag to observe logs as the run is happening on CI, given that this test takes ~40 minutes to run.
+	# Add the -v flag to observe logs as the run is happening on CI, given that this test takes ~20 minutes to run.
 	# Good to have early feedback when needed.
-	BACKEND=preprod go test -v -timeout 60m ./e2e -parallel 4
+	BACKEND=preprod go test -v -timeout 30m ./e2e -parallel 8
 
 # Very simple fuzzer which generates random bytes arrays and sends them to the proxy using the standard client.
 # To clean the cached corpus, run `go clean -fuzzcache` before running this.

--- a/testutils/setup.go
+++ b/testutils/setup.go
@@ -278,6 +278,7 @@ func BuildTestSuiteConfig(testCfg TestConfig) config.AppConfig {
 				SvcManagerAddr:           svcManagerAddress,
 			},
 			MaxBlobSizeBytes: maxBlobLengthBytes,
+			PutRetries:       3,
 		},
 		VerifierConfigV1: verify.Config{
 			VerifyCerts:          false,
@@ -320,7 +321,7 @@ func BuildTestSuiteConfig(testCfg TestConfig) config.AppConfig {
 				PayloadClientConfig: payloadClientConfig,
 				RelayTimeout:        5 * time.Second,
 			},
-			PutRetries:                 1,
+			PutRetries:                 3,
 			MaxBlobSizeBytes:           maxBlobLengthBytes,
 			EigenDACertVerifierAddress: certVerifierAddress,
 		},
@@ -340,15 +341,12 @@ func BuildTestSuiteConfig(testCfg TestConfig) config.AppConfig {
 	switch {
 	case testCfg.UseKeccak256ModeS3:
 		proxyConfig.StorageConfig = createS3Config(proxyConfig.StorageConfig)
-
 	case testCfg.UseS3Caching:
 		proxyConfig.StorageConfig.CacheTargets = []string{"S3"}
 		proxyConfig.StorageConfig = createS3Config(proxyConfig.StorageConfig)
-
 	case testCfg.UseS3Fallback:
 		proxyConfig.StorageConfig.FallbackTargets = []string{"S3"}
 		proxyConfig.StorageConfig = createS3Config(proxyConfig.StorageConfig)
-
 	case testCfg.UseRedisCaching:
 		proxyConfig.StorageConfig.CacheTargets = []string{"redis"}
 		proxyConfig.StorageConfig = createRedisConfig(proxyConfig.StorageConfig)


### PR DESCRIPTION
- Configure `PutRetries` to be 3 for both v1 and v2
    - previously was undefined for v1, which could cause tests to hang if dispersal kept failing
    - chose 3 for both v1 and v2 since it seems a reasonable value
- Increase parallelism, to speed up e2e tests