### PR TITLE
chore(make): rename build command

### DIFF
--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -124,7 +124,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
-      - run: make eigenda-proxy
+      - run: make build
 
   build-docker:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN go mod download
 COPY . .
 
 # Build the application binary
-RUN make eigenda-proxy
+RUN make build
 
 # Use alpine to run app
 FROM alpine:3.16

--- a/Makefile
+++ b/Makefile
@@ -7,23 +7,21 @@ LDFLAGSSTRING +=-X main.Date=$(BUILD_TIME)
 LDFLAGSSTRING +=-X main.Version=$(GIT_TAG)
 LDFLAGS := -ldflags "$(LDFLAGSSTRING)"
 
-.PHONY: eigenda-proxy
-eigenda-proxy:
+build:
 	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) go build -v $(LDFLAGS) -o ./bin/eigenda-proxy ./cmd/server
 
-.PHONY: docker-build
+clean:
+	rm bin/eigenda-proxy
+
 docker-build:
 	# we only use this to build the docker image locally, so we give it the dev tag as a reminder
 	@docker build -t ghcr.io/layr-labs/eigenda-proxy:dev .
 
-run-memstore-server:
+run-memstore-server: build
 	./bin/eigenda-proxy --memstore.enabled --metrics.enabled
 
 disperse-test-blob:
 	curl -X POST -d my-blob-content http://127.0.0.1:3100/put/
-
-clean:
-	rm bin/eigenda-proxy
 
 # Runs all tests, excluding e2e
 test-unit:
@@ -94,6 +92,4 @@ op-devnet-allocs:
 benchmark:
 	go test -benchmem -run=^$ -bench . ./benchmark -test.parallel 4
 
-.PHONY: \
-	clean \
-	test
+.PHONY: build clean docker-build test lint format benchmark

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ format:
 
 ## calls --help on binary and routes output to file while ignoring dynamic fields specific
 ## to indivdual builds (e.g, version)
-gen-static-help-output: eigenda-proxy
+gen-static-help-output: build
 	@echo "Storing binary output to docs/help_out.txt"
 	@./bin/eigenda-proxy --help | sed '/^VERSION:/ {N;d;}' > docs/help_out.txt
 


### PR DESCRIPTION
Used to be "eigenda-proxy". Renamed for consistency with `docker-build` command. Also most people are used to just typing `make build`, which doesn't require knowing the binary name.

<!-- If your PR fixes an open issue, use `Closes #NNN` to link your PR with the
issue, replacing `#NNN` with the issue number you are fixing -->

## Fixes Issue

<!-- Example: Closes #NNN -->
Fixes #

## Changes proposed

<!-- List all the proposed changes in your PR -->
<!-- Add the screenshots of the changes below if applicable -->

### Screenshots (Optional)

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
