### PR TITLE
Implement admin endpoints for v2 dispersal

### DIFF
--- a/.env.exampleV1AndV2.holesky
+++ b/.env.exampleV1AndV2.holesky
@@ -102,10 +102,10 @@ EIGENDA_PROXY_STORAGE_BACKENDS_TO_ENABLE=V1,V2
 
 # Enable blob dispersal and retrieval against EigenDA V2 protocol
 # For migration: Start with 'false' and toggle at runtime using admin endpoints
-EIGENDA_PROXY_STORAGE_DISPERSE_TO_V2=false
+EIGENDA_PROXY_STORAGE_DISPERSE_TO_V2=true
 
 # Enable administrative HTTP endpoints for runtime configuration (needed for on-the-fly migration)
-EIGENDA_PROXY_ADMIN_ENDPOINTS_ENABLED=true
+EIGENDA_PROXY_ADMIN_ENDPOINTS_ENABLED=false
 
 # === Shared KZG Configuration ===
 

--- a/.env.exampleV1AndV2.holesky
+++ b/.env.exampleV1AndV2.holesky
@@ -105,7 +105,8 @@ EIGENDA_PROXY_STORAGE_BACKENDS_TO_ENABLE=V1,V2
 EIGENDA_PROXY_STORAGE_DISPERSE_TO_V2=true
 
 # Enable administrative HTTP endpoints for runtime configuration (needed for on-the-fly migration)
-EIGENDA_PROXY_ADMIN_ENDPOINTS_ENABLED=false
+# Set to "admin" to enable admin endpoints, or leave empty to disable
+EIGENDA_PROXY_API_ENABLED=
 
 # === Shared KZG Configuration ===
 

--- a/.env.exampleV1AndV2.holesky
+++ b/.env.exampleV1AndV2.holesky
@@ -101,7 +101,11 @@ EIGENDA_PROXY_EIGENDA_V2_MAX_BLOB_LENGTH=1MiB
 EIGENDA_PROXY_STORAGE_BACKENDS_TO_ENABLE=V1,V2
 
 # Enable blob dispersal and retrieval against EigenDA V2 protocol
-EIGENDA_PROXY_STORAGE_DISPERSE_TO_V2=true
+# For migration: Start with 'false' and toggle at runtime using admin endpoints
+EIGENDA_PROXY_STORAGE_DISPERSE_TO_V2=false
+
+# Enable administrative HTTP endpoints for runtime configuration (needed for on-the-fly migration)
+EIGENDA_PROXY_ADMIN_ENDPOINTS_ENABLED=true
 
 # === Shared KZG Configuration ===
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,38 @@ Response:
   Body: <preimage_bytes>
 ```
 
+#### Admin Routes
+
+The proxy provides administrative endpoints to control runtime behavior. By default, these endpoints are disabled and must be explicitly enabled through configuration.
+
+To enable admin endpoints, set the `--admin-endpoints-enabled` flag to `true` or set the environment variable `EIGENDA_PROXY_ADMIN_ENDPOINTS_ENABLED=true` when starting the proxy server.
+
+When enabled, the following admin endpoints are available:
+
+```text
+Request:
+  GET /admin/v2-dispersal
+
+Response:
+  200 OK
+  Content-Type: application/json
+  Body: {"disperseToV2": boolean}
+```
+
+```text
+Request:
+  PUT /admin/v2-dispersal
+  Content-Type: application/json
+  Body: {"disperseToV2": boolean}
+
+Response:
+  200 OK
+  Content-Type: application/json
+  Body: {"disperseToV2": boolean}
+```
+
+These endpoints allow operators to check and set whether blobs are dispersed to EigenDA V1 or V2. The GET endpoint retrieves the current state, while the PUT endpoint idempotently updates the state to the specified value. The `disperseToV2` value in the response represents the current state after any changes have been applied.
+
 ### Deployment Against Real EigenDA Network
 
 We also provide network-specific example env configuration files in `.env.example.holesky` and `.env.example.mainnet` as a place to get started:

--- a/README.md
+++ b/README.md
@@ -138,8 +138,16 @@ and must be explicitly enabled through configuration.
 > **SECURITY WARNING:** The admin endpoints should NEVER be publicly accessible. These endpoints 
 > do not implement authentication or authorization controls and should only be exposed on internal networks.
 
-To enable admin endpoints, set the `--admin-endpoints-enabled` flag to `true` or set the environment variable 
-`EIGENDA_PROXY_ADMIN_ENDPOINTS_ENABLED=true` when starting the proxy server.
+To enable admin endpoints, include "admin" in the `--api-enabled` flag value or set the environment variable 
+`EIGENDA_PROXY_API_ENABLED=admin` when starting the proxy server. For example:
+  
+```bash
+# Enable admin API
+./bin/eigenda-proxy --api-enabled admin
+
+# Example of enabling multiple APIs (note: 'metrics' shown for illustration only and is not currently implemented)
+./bin/eigenda-proxy --api-enabled admin,metrics
+```
 
 When enabled, the following admin endpoints are available:
 
@@ -187,7 +195,7 @@ This approach allows you to switch from V1 to V2 while the proxy is running, wit
       - See `.env.exampleV1AndV2.holesky` for an example configuration
    - Set `EIGENDA_PROXY_STORAGE_DISPERSE_TO_V2=false` in your configuration
       - This ensures that the proxy will continue dispersing to the V1 backend, until it's time to migrate
-   - Set `EIGENDA_PROXY_ADMIN_ENDPOINTS_ENABLED=true` to expose the admin API
+   - Set `EIGENDA_PROXY_API_ENABLED=admin` to expose the admin API
       - This allows runtime switching between V1 and V2 without service restart
 
 2. **Runtime Migration**

--- a/README.md
+++ b/README.md
@@ -132,35 +132,43 @@ Response:
 
 #### Admin Routes
 
-The proxy provides administrative endpoints to control runtime behavior. By default, these endpoints are disabled and must be explicitly enabled through configuration.
+The proxy provides administrative endpoints to control runtime behavior. By default, these endpoints are disabled 
+and must be explicitly enabled through configuration.
 
-To enable admin endpoints, set the `--admin-endpoints-enabled` flag to `true` or set the environment variable `EIGENDA_PROXY_ADMIN_ENDPOINTS_ENABLED=true` when starting the proxy server.
+To enable admin endpoints, set the `--admin-endpoints-enabled` flag to `true` or set the environment variable 
+`EIGENDA_PROXY_ADMIN_ENDPOINTS_ENABLED=true` when starting the proxy server.
 
 When enabled, the following admin endpoints are available:
 
 ```text
 Request:
-  GET /admin/v2-dispersal
+  GET /admin/eigenda-dispersal-backend
 
 Response:
   200 OK
   Content-Type: application/json
-  Body: {"disperseToV2": boolean}
+  Body: {"eigenDADispersalBackend": string}
 ```
 
 ```text
 Request:
-  PUT /admin/v2-dispersal
+  PUT /admin/eigenda-dispersal-backend
   Content-Type: application/json
-  Body: {"disperseToV2": boolean}
+  Body: {"eigenDADispersalBackend": string}
 
 Response:
   200 OK
   Content-Type: application/json
-  Body: {"disperseToV2": boolean}
+  Body: {"eigenDADispersalBackend": string}
 ```
 
-These endpoints allow operators to check and set whether blobs are dispersed to EigenDA V1 or V2. The GET endpoint retrieves the current state, while the PUT endpoint idempotently updates the state to the specified value. The `disperseToV2` value in the response represents the current state after any changes have been applied.
+These endpoints allow operators to check and set which EigenDA backend version is used for blob dispersal. 
+The GET endpoint retrieves the current state, while the PUT endpoint idempotently updates the state to the specified value. 
+The `eigenDADispersalBackend` value represents the current backend being used after any changes have been applied.
+
+Valid values for `eigenDADispersalBackend` are:
+- `"v1"`: Use EigenDA V1 backend for dispersal
+- `"v2"`: Use EigenDA V2 backend for dispersal
 
 ### Migrating from EigenDA V1 to V2
 
@@ -179,12 +187,12 @@ This approach allows you to switch from V1 to V2 while the proxy is running, wit
    - Set `EIGENDA_PROXY_ADMIN_ENDPOINTS_ENABLED=true` to expose the admin API
       - This allows runtime switching between V1 and V2 without service restart
 
-2**Runtime Migration**
+2. **Runtime Migration**
    - When ready to migrate to V2, use the admin endpoint to switch dispersal targets:
    ```
-   curl -X PUT http://localhost:3100/admin/v2-dispersal \
+   curl -X PUT http://localhost:3100/admin/eigenda-dispersal-backend \
      -H "Content-Type: application/json" \
-     -d '{"disperseToV2": true}'
+     -d '{"eigenDADispersalBackend": "v2"}'
    ```
 
 This migration path allows for a seamless transition from V1 to V2 without service downtime and provides the ability 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ Response:
 The proxy provides administrative endpoints to control runtime behavior. By default, these endpoints are disabled 
 and must be explicitly enabled through configuration.
 
+> **SECURITY WARNING:** The admin endpoints should NEVER be publicly accessible. These endpoints 
+> do not implement authentication or authorization controls and should only be exposed on internal networks.
+
 To enable admin endpoints, set the `--admin-endpoints-enabled` flag to `true` or set the environment variable 
 `EIGENDA_PROXY_ADMIN_ENDPOINTS_ENABLED=true` when starting the proxy server.
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Features:
   - [REST API Routes](#rest-api-routes)
     - [Standard Routes](#standard-routes)
     - [Optimism Routes](#optimism-routes)
+    - [Admin Routes](#admin-routes)
+  - [Migrating from EigenDA V1 to V2](#migrating-from-eigenda-v1-to-v2)
+    - [On-the-Fly Migration](#on-the-fly-migration)
+    - [Migration With Service Restart](#migration-with-service-restart)
   - [Deployment Against Real EigenDA Network](#deployment-against-real-eigenda-network)
   - [Features and Configuration Options (flags/env vars)](#features-and-configuration-options-flagsenv-vars)
   - [Requirements / Dependencies](#requirements--dependencies)
@@ -158,6 +162,52 @@ Response:
 
 These endpoints allow operators to check and set whether blobs are dispersed to EigenDA V1 or V2. The GET endpoint retrieves the current state, while the PUT endpoint idempotently updates the state to the specified value. The `disperseToV2` value in the response represents the current state after any changes have been applied.
 
+### Migrating from EigenDA V1 to V2
+
+There are two approaches for migrating from EigenDA V1 to V2: on-the-fly migration using runtime configuration,
+and migration with a service restart. Choose the approach that best fits your operational requirements.
+
+#### On-the-Fly Migration
+
+This approach allows you to switch from V1 to V2 while the proxy is running, without any service interruption:
+
+1. **Configure Both V1 and V2 Backends**
+   - Use a configuration file that includes settings for both V1 and V2 backends
+      - See `.env.exampleV1AndV2.holesky` for an example configuration
+   - Set `EIGENDA_PROXY_STORAGE_DISPERSE_TO_V2=false` in your configuration
+      - This ensures that the proxy will continue dispersing to the V1 backend, until it's time to migrate
+   - Set `EIGENDA_PROXY_ADMIN_ENDPOINTS_ENABLED=true` to expose the admin API
+      - This allows runtime switching between V1 and V2 without service restart
+
+2**Runtime Migration**
+   - When ready to migrate to V2, use the admin endpoint to switch dispersal targets:
+   ```
+   curl -X PUT http://localhost:3100/admin/v2-dispersal \
+     -H "Content-Type: application/json" \
+     -d '{"disperseToV2": true}'
+   ```
+
+This migration path allows for a seamless transition from V1 to V2 without service downtime and provides the ability 
+to roll back to V1 if needed.
+
+#### Migration With Service Restart
+
+If you prefer a more controlled migration with explicit service updates, follow this approach:
+
+1. **Initial Configuration (V1 Only)**
+   - Start proxy with a V1-only configuration
+      - See `.env.exampleV1.holesky` for an example configuration
+
+2. **Prepare V2 Configuration**
+   - Prepare a configuration file that includes settings for both V1 and V2 backends
+      - See `.env.exampleV1AndV2.holesky` for an example configuration
+   - Set `EIGENDA_PROXY_STORAGE_DISPERSE_TO_V2=true`, so that the proxy started with this config will immediately
+enable V2 dispersal
+
+3. **Scheduled Migration**
+   - During a planned migration window, stop the V1-only proxy service
+   - Restart the proxy service, using the prepared V2 configuration
+
 ### Deployment Against Real EigenDA Network
 
 We also provide network-specific example env configuration files in `.env.example.holesky` and `.env.example.mainnet` as a place to get started:
@@ -237,7 +287,7 @@ In order to disperse to the EigenDA V1 network in production, or at high through
 
 #### Ethereum Node
 
-A normal (non-archival) Ethereum node is sufficient for running the proxy with [cert verification](#certificate-verification) turned on. This is because all parameters that are read from the chain are either:
+A normal (non-archival) Ethereum node is sufficient for running the proxy with cert verification turned on. This is because all parameters that are read from the chain are either:
 1. immutable (eg: [securityThresholds](https://github.com/Layr-Labs/eigenda/blob/a6dd724acdf732af483fd2d9a86325febe7ebdcd/contracts/src/core/EigenDAThresholdRegistryStorage.sol#L30)), or
 2. are upgradeable but have all the historical versions available in contract storage (eg: [versioninedBlobParams](https://github.com/Layr-Labs/eigenda/blob/a6dd724acdf732af483fd2d9a86325febe7ebdcd/contracts/src/core/EigenDAThresholdRegistryStorage.sol#L27))
 
@@ -270,11 +320,11 @@ The proxy fundamentally acts as a bridge between the rollup nodes and the EigenD
 
 ![Posting Blobs](./resources/payload-blob-poly-lifecycle.png)
 
-The rollup payload is submitted via a POST request to the proxy. Proxy encodes the payload into a blob and submits it to the EigenDA disperser. After the DACertificate is available via the GetBlobStatus endpoint, it is encoded using the requested [commitment schema](#commitment-schemas) and sent back to the rollup sequencer. The sequencer then submits the commitment to the rollup's batcher inbox.
+The rollup payload is submitted via a POST request to the proxy. Proxy encodes the payload into a blob and submits it to the EigenDA disperser. After the DACertificate is available via the GetBlobStatus endpoint, it is encoded using the requested [commitment schema](#rollup-commitment-schemas) and sent back to the rollup sequencer. The sequencer then submits the commitment to the rollup's batcher inbox.
 
 ### Retrieving Payloads
 
-Validator nodes proceed with the exact reverse process as that used by the sequencer in the [posting blobs](#posting-blobs) section. The rollup validator submits a GET request to the proxy with the DACert in the body. The proxy validates the cert, fetches the corresponding blob from EigenDA, validates it, decodes it back into the rollup payload, and returns it the rollup node.
+Validator nodes proceed with the exact reverse process as that used by the sequencer in the [posting payloads](#posting-payloads) section. The rollup validator submits a GET request to the proxy with the DACert in the body. The proxy validates the cert, fetches the corresponding blob from EigenDA, validates it, decodes it back into the rollup payload, and returns it the rollup node.
 
 ### Rollup Commitment Schemas
 

--- a/common/common.go
+++ b/common/common.go
@@ -102,3 +102,15 @@ func StringToEigenDABackend(inputString string) (EigenDABackend, error) {
 		return 0, fmt.Errorf("invalid backend option: %s", inputString)
 	}
 }
+
+// EigenDABackendToString converts an EigenDABackend enum to its string representation
+func EigenDABackendToString(backend EigenDABackend) string {
+	switch backend {
+	case V1EigenDABackend:
+		return "v1"
+	case V2EigenDABackend:
+		return "v2"
+	default:
+		return "unknown"
+	}
+}

--- a/config/flags.go
+++ b/config/flags.go
@@ -27,6 +27,7 @@ const (
 	S3Category              = "S3 Cache/Fallback"
 	VerifierCategory        = "Cert Verifier (V1 only)"
 	KZGCategory             = "KZG"
+	ProxyServerCategory     = "Proxy Server"
 )
 
 const (
@@ -35,26 +36,29 @@ const (
 	AdminEndpointsEnabledFlagName = "admin-endpoints-enabled"
 )
 
-func CLIFlags() []cli.Flag {
+func CLIFlags(envPrefix string, category string) []cli.Flag {
 	// TODO: Decompose all flags into constituent parts based on their respective category / usage
 	flags := []cli.Flag{
 		&cli.StringFlag{
-			Name:    ListenAddrFlagName,
-			Usage:   "Server listening address",
-			Value:   "0.0.0.0",
-			EnvVars: common.PrefixEnvVar(common.GlobalPrefix, "ADDR"),
+			Name:     ListenAddrFlagName,
+			Usage:    "Server listening address",
+			Value:    "0.0.0.0",
+			EnvVars:  common.PrefixEnvVar(envPrefix, "ADDR"),
+			Category: category,
 		},
 		&cli.IntFlag{
-			Name:    PortFlagName,
-			Usage:   "Server listening port",
-			Value:   3100,
-			EnvVars: common.PrefixEnvVar(common.GlobalPrefix, "PORT"),
+			Name:     PortFlagName,
+			Usage:    "Server listening port",
+			Value:    3100,
+			EnvVars:  common.PrefixEnvVar(envPrefix, "PORT"),
+			Category: category,
 		},
 		&cli.BoolFlag{
-			Name:    AdminEndpointsEnabledFlagName,
-			Usage:   "Enable administrative HTTP endpoints for runtime configuration",
-			Value:   false,
-			EnvVars: common.PrefixEnvVar(common.GlobalPrefix, "ADMIN_ENDPOINTS_ENABLED"),
+			Name:     AdminEndpointsEnabledFlagName,
+			Usage:    "Enable administrative HTTP endpoints for runtime configuration",
+			Value:    false,
+			EnvVars:  common.PrefixEnvVar(envPrefix, "ADMIN_ENDPOINTS_ENABLED"),
+			Category: category,
 		},
 	}
 
@@ -65,7 +69,7 @@ func CLIFlags() []cli.Flag {
 var Flags = []cli.Flag{}
 
 func init() {
-	Flags = CLIFlags()
+	Flags = CLIFlags(common.GlobalPrefix, ProxyServerCategory)
 	Flags = append(Flags, logging.CLIFlags(common.GlobalPrefix, LoggingFlagsCategory)...)
 	Flags = append(Flags, metrics.CLIFlags(common.GlobalPrefix, MetricsFlagCategory)...)
 	Flags = append(Flags, eigendaflags.CLIFlags(common.GlobalPrefix, EigenDAClientCategory)...)

--- a/config/flags.go
+++ b/config/flags.go
@@ -30,8 +30,9 @@ const (
 )
 
 const (
-	ListenAddrFlagName = "addr"
-	PortFlagName       = "port"
+	ListenAddrFlagName            = "addr"
+	PortFlagName                  = "port"
+	AdminEndpointsEnabledFlagName = "admin-endpoints-enabled"
 )
 
 func CLIFlags() []cli.Flag {
@@ -48,6 +49,12 @@ func CLIFlags() []cli.Flag {
 			Usage:   "Server listening port",
 			Value:   3100,
 			EnvVars: common.PrefixEnvVar(common.GlobalPrefix, "PORT"),
+		},
+		&cli.BoolFlag{
+			Name:    AdminEndpointsEnabledFlagName,
+			Usage:   "Enable administrative HTTP endpoints for runtime configuration",
+			Value:   false,
+			EnvVars: common.PrefixEnvVar(common.GlobalPrefix, "ADMIN_ENDPOINTS_ENABLED"),
 		},
 	}
 

--- a/config/flags.go
+++ b/config/flags.go
@@ -31,9 +31,10 @@ const (
 )
 
 const (
-	ListenAddrFlagName            = "addr"
-	PortFlagName                  = "port"
-	AdminEndpointsEnabledFlagName = "admin-endpoints-enabled"
+	ListenAddrFlagName  = "addr"
+	PortFlagName        = "port"
+	APIsEnabledFlagName = "api-enabled"
+	AdminAPIType        = "admin"
 )
 
 func CLIFlags(envPrefix string, category string) []cli.Flag {
@@ -53,11 +54,11 @@ func CLIFlags(envPrefix string, category string) []cli.Flag {
 			EnvVars:  common.PrefixEnvVar(envPrefix, "PORT"),
 			Category: category,
 		},
-		&cli.BoolFlag{
-			Name:     AdminEndpointsEnabledFlagName,
-			Usage:    "Enable administrative HTTP endpoints for runtime configuration",
-			Value:    false,
-			EnvVars:  common.PrefixEnvVar(envPrefix, "ADMIN_ENDPOINTS_ENABLED"),
+		&cli.StringSliceFlag{
+			Name:     APIsEnabledFlagName,
+			Usage:    "List of API types to enable (e.g. admin)",
+			Value:    cli.NewStringSlice(),
+			EnvVars:  common.PrefixEnvVar(envPrefix, "API_ENABLED"),
 			Category: category,
 		},
 	}

--- a/config/proxy_config.go
+++ b/config/proxy_config.go
@@ -65,8 +65,9 @@ func ReadProxyConfig(ctx *cli.Context) (ProxyConfig, error) {
 
 	cfg := ProxyConfig{
 		ServerConfig: ServerConfig{
-			Host: ctx.String(ListenAddrFlagName),
-			Port: ctx.Int(PortFlagName),
+			Host:                  ctx.String(ListenAddrFlagName),
+			Port:                  ctx.Int(PortFlagName),
+			AdminEndpointsEnabled: ctx.Bool(AdminEndpointsEnabledFlagName),
 		},
 		ClientConfigV1:   clientConfigV1,
 		VerifierConfigV1: verifierConfigV1,

--- a/config/proxy_config.go
+++ b/config/proxy_config.go
@@ -65,9 +65,9 @@ func ReadProxyConfig(ctx *cli.Context) (ProxyConfig, error) {
 
 	cfg := ProxyConfig{
 		ServerConfig: ServerConfig{
-			Host:                  ctx.String(ListenAddrFlagName),
-			Port:                  ctx.Int(PortFlagName),
-			AdminEndpointsEnabled: ctx.Bool(AdminEndpointsEnabledFlagName),
+			Host:        ctx.String(ListenAddrFlagName),
+			Port:        ctx.Int(PortFlagName),
+			EnabledAPIs: ctx.StringSlice(APIsEnabledFlagName),
 		},
 		ClientConfigV1:   clientConfigV1,
 		VerifierConfigV1: verifierConfigV1,

--- a/config/server_config.go
+++ b/config/server_config.go
@@ -5,7 +5,7 @@ type ServerConfig struct {
 	Host string
 	Port int
 	// AdminEndpointsEnabled controls whether administrative HTTP endpoints are exposed.
-	// When false (default), administrative endpoints like /admin/v2-dispersal are not registered.
+	// When false (default), administrative endpoints like /admin/eigenda-dispersal-backend are not registered.
 	// When true, these endpoints are available for runtime configuration changes.
 	AdminEndpointsEnabled bool
 }

--- a/config/server_config.go
+++ b/config/server_config.go
@@ -4,4 +4,8 @@ package config
 type ServerConfig struct {
 	Host string
 	Port int
+	// AdminEndpointsEnabled controls whether administrative HTTP endpoints are exposed.
+	// When false (default), administrative endpoints like /admin/v2-dispersal are not registered.
+	// When true, these endpoints are available for runtime configuration changes.
+	AdminEndpointsEnabled bool
 }

--- a/config/server_config.go
+++ b/config/server_config.go
@@ -1,11 +1,20 @@
 package config
 
+import (
+	"slices"
+)
+
 // ServerConfig ... Config for the proxy HTTP server
 type ServerConfig struct {
 	Host string
 	Port int
-	// AdminEndpointsEnabled controls whether administrative HTTP endpoints are exposed.
-	// When false (default), administrative endpoints like /admin/eigenda-dispersal-backend are not registered.
-	// When true, these endpoints are available for runtime configuration changes.
-	AdminEndpointsEnabled bool
+	// EnabledAPIs contains the list of API types that are enabled.
+	// When empty (default), no special API endpoints are registered.
+	// Example: If it contains "admin", administrative endpoints like /admin/eigenda-dispersal-backend will be available.
+	EnabledAPIs []string
+}
+
+// IsAPIEnabled checks if a specific API type is enabled
+func (c *ServerConfig) IsAPIEnabled(apiType string) bool {
+	return slices.Contains(c.EnabledAPIs, apiType)
 }

--- a/docs/help_out.txt
+++ b/docs/help_out.txt
@@ -13,11 +13,8 @@ COMMANDS:
    help, h  Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
-   --addr value               Server listening address (default: "0.0.0.0") [$EIGENDA_PROXY_ADDR]
-   --admin-endpoints-enabled  Enable administrative HTTP endpoints for runtime configuration (default: false) [$EIGENDA_PROXY_ADMIN_ENDPOINTS_ENABLED]
-   --help, -h                 show help
-   --port value               Server listening port (default: 3100) [$EIGENDA_PROXY_PORT]
-   --version, -v              print the version
+   --help, -h     show help
+   --version, -v  print the version
 
    Cert Verifier (V1 only)
 
@@ -98,6 +95,12 @@ GLOBAL OPTIONS:
    --metrics.addr value  Metrics listening address (default: "0.0.0.0") [$EIGENDA_PROXY_METRICS_ADDR]
    --metrics.enabled     Enable the metrics server (default: false) [$EIGENDA_PROXY_METRICS_ENABLED]
    --metrics.port value  Metrics listening port (default: 7300) [$EIGENDA_PROXY_METRICS_PORT]
+
+   Proxy Server
+
+   --addr value               Server listening address (default: "0.0.0.0") [$EIGENDA_PROXY_ADDR]
+   --admin-endpoints-enabled  Enable administrative HTTP endpoints for runtime configuration (default: false) [$EIGENDA_PROXY_ADMIN_ENDPOINTS_ENABLED]
+   --port value               Server listening port (default: 3100) [$EIGENDA_PROXY_PORT]
 
    Redis Cache/Fallback
 

--- a/docs/help_out.txt
+++ b/docs/help_out.txt
@@ -13,10 +13,11 @@ COMMANDS:
    help, h  Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
-   --addr value   Server listening address (default: "0.0.0.0") [$EIGENDA_PROXY_ADDR]
-   --help, -h     show help
-   --port value   Server listening port (default: 3100) [$EIGENDA_PROXY_PORT]
-   --version, -v  print the version
+   --addr value               Server listening address (default: "0.0.0.0") [$EIGENDA_PROXY_ADDR]
+   --admin-endpoints-enabled  Enable administrative HTTP endpoints for runtime configuration (default: false) [$EIGENDA_PROXY_ADMIN_ENDPOINTS_ENABLED]
+   --help, -h                 show help
+   --port value               Server listening port (default: 3100) [$EIGENDA_PROXY_PORT]
+   --version, -v              print the version
 
    Cert Verifier (V1 only)
 

--- a/docs/help_out.txt
+++ b/docs/help_out.txt
@@ -98,9 +98,9 @@ GLOBAL OPTIONS:
 
    Proxy Server
 
-   --addr value               Server listening address (default: "0.0.0.0") [$EIGENDA_PROXY_ADDR]
-   --admin-endpoints-enabled  Enable administrative HTTP endpoints for runtime configuration (default: false) [$EIGENDA_PROXY_ADMIN_ENDPOINTS_ENABLED]
-   --port value               Server listening port (default: 3100) [$EIGENDA_PROXY_PORT]
+   --addr value                                 Server listening address (default: "0.0.0.0") [$EIGENDA_PROXY_ADDR]
+   --api-enabled value [ --api-enabled value ]  List of API types to enable (e.g. admin) [$EIGENDA_PROXY_API_ENABLED]
+   --port value                                 Server listening port (default: 3100) [$EIGENDA_PROXY_PORT]
 
    Redis Cache/Fallback
 

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -349,6 +349,27 @@ func TestEigenDADispersalBackendEndpoints(t *testing.T) {
 			require.Equal(t, common.EigenDABackendToString(common.V1EigenDABackend), response.EigenDADispersalBackend)
 		})
 
+		// Test PUT endpoint with invalid input
+		t.Run("Set EigenDA Dispersal Backend With Invalid Value", func(t *testing.T) {
+			requestBody := struct {
+				EigenDADispersalBackend string `json:"eigenDADispersalBackend"`
+			}{
+				EigenDADispersalBackend: "invalid",
+			}
+			jsonBody, err := json.Marshal(requestBody)
+			require.NoError(t, err)
+
+			req := httptest.NewRequest(http.MethodPut, "/admin/eigenda-dispersal-backend", bytes.NewReader(jsonBody))
+			rec := httptest.NewRecorder()
+
+			r := mux.NewRouter()
+			server := NewServer(testCfg, mockStorageMgr, testLogger, metrics.NoopMetrics)
+			server.RegisterRoutes(r)
+			r.ServeHTTP(rec, req)
+
+			require.Equal(t, http.StatusBadRequest, rec.Code)
+		})
+
 		// Test PUT endpoint to set the EigenDA dispersal backend
 		t.Run("Set EigenDA Dispersal Backend", func(t *testing.T) {
 			requestBody := struct {

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -297,7 +297,7 @@ func TestHandlerPutErrors(t *testing.T) {
 	}
 }
 
-func TestDisperseToV2Endpoints(t *testing.T) {
+func TestEigenDADispersalBackendEndpoints(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockStorageMgr := mocks.NewMockIManager(ctrl)
@@ -312,7 +312,7 @@ func TestDisperseToV2Endpoints(t *testing.T) {
 		}
 
 		// Test GET endpoint with admin disabled
-		req := httptest.NewRequest(http.MethodGet, "/admin/v2-dispersal", nil)
+		req := httptest.NewRequest(http.MethodGet, "/admin/eigenda-dispersal-backend", nil)
 		rec := httptest.NewRecorder()
 
 		r := mux.NewRouter()
@@ -330,8 +330,8 @@ func TestDisperseToV2Endpoints(t *testing.T) {
 		mockStorageMgr.EXPECT().DisperseToV2().Return(false)
 
 		// Test GET endpoint first to verify initial state
-		t.Run("Get V2 Dispersal State", func(t *testing.T) {
-			req := httptest.NewRequest(http.MethodGet, "/admin/v2-dispersal", nil)
+		t.Run("Get EigenDA Dispersal Backend", func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/admin/eigenda-dispersal-backend", nil)
 			rec := httptest.NewRecorder()
 
 			r := mux.NewRouter()
@@ -342,19 +342,19 @@ func TestDisperseToV2Endpoints(t *testing.T) {
 			require.Equal(t, http.StatusOK, rec.Code)
 
 			var response struct {
-				DisperseToV2 bool `json:"disperseToV2"`
+				EigenDADispersalBackend string `json:"eigenDADispersalBackend"`
 			}
 			err := json.Unmarshal(rec.Body.Bytes(), &response)
 			require.NoError(t, err)
-			require.False(t, response.DisperseToV2)
+			require.Equal(t, common.EigenDABackendToString(common.V1EigenDABackend), response.EigenDADispersalBackend)
 		})
 
-		// Test PUT endpoint to set state to true
-		t.Run("Set V2 Dispersal State", func(t *testing.T) {
+		// Test PUT endpoint to set the EigenDA dispersal backend
+		t.Run("Set EigenDA Dispersal Backend", func(t *testing.T) {
 			requestBody := struct {
-				DisperseToV2 bool `json:"disperseToV2"`
+				EigenDADispersalBackend string `json:"eigenDADispersalBackend"`
 			}{
-				DisperseToV2: true,
+				EigenDADispersalBackend: common.EigenDABackendToString(common.V2EigenDABackend),
 			}
 			jsonBody, err := json.Marshal(requestBody)
 			require.NoError(t, err)
@@ -362,7 +362,7 @@ func TestDisperseToV2Endpoints(t *testing.T) {
 			mockStorageMgr.EXPECT().SetDisperseToV2(true)
 			mockStorageMgr.EXPECT().DisperseToV2().Return(true)
 
-			req := httptest.NewRequest(http.MethodPut, "/admin/v2-dispersal", bytes.NewReader(jsonBody))
+			req := httptest.NewRequest(http.MethodPut, "/admin/eigenda-dispersal-backend", bytes.NewReader(jsonBody))
 			rec := httptest.NewRecorder()
 
 			r := mux.NewRouter()
@@ -373,11 +373,11 @@ func TestDisperseToV2Endpoints(t *testing.T) {
 			require.Equal(t, http.StatusOK, rec.Code)
 
 			var response struct {
-				DisperseToV2 bool `json:"disperseToV2"`
+				EigenDADispersalBackend string `json:"eigenDADispersalBackend"`
 			}
 			err = json.Unmarshal(rec.Body.Bytes(), &response)
 			require.NoError(t, err)
-			require.True(t, response.DisperseToV2)
+			require.Equal(t, common.EigenDABackendToString(common.V2EigenDABackend), response.EigenDADispersalBackend)
 		})
 	})
 }

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -29,9 +29,9 @@ import (
 var (
 	testLogger = logging.NewTextSLogger(os.Stdout, &logging.SLoggerOptions{})
 	testCfg    = config.ServerConfig{
-		Host:                  "localhost",
-		Port:                  0,
-		AdminEndpointsEnabled: true, // Enable admin endpoints for testing
+		Host:        "localhost",
+		Port:        0,
+		EnabledAPIs: []string{config.AdminAPIType}, // Enable admin API for testing
 	}
 )
 
@@ -306,9 +306,9 @@ func TestEigenDADispersalBackendEndpoints(t *testing.T) {
 	t.Run("Admin Endpoints Disabled", func(t *testing.T) {
 		// Create server config with admin endpoints disabled
 		adminDisabledCfg := config.ServerConfig{
-			Host:                  "localhost",
-			Port:                  0,
-			AdminEndpointsEnabled: false,
+			Host:        "localhost",
+			Port:        0,
+			EnabledAPIs: []string{}, // Empty list means no APIs are enabled
 		}
 
 		// Test GET endpoint with admin disabled

--- a/server/routing.go
+++ b/server/routing.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/Layr-Labs/eigenda-proxy/commitments"
+	"github.com/Layr-Labs/eigenda-proxy/config"
 	"github.com/gorilla/mux"
 )
 
@@ -87,7 +88,7 @@ func (svr *Server) RegisterRoutes(r *mux.Router) {
 	r.HandleFunc("/health", withLogging(svr.handleHealth, svr.log)).Methods("GET")
 
 	// Only register admin endpoints if explicitly enabled in configuration
-	if svr.config.AdminEndpointsEnabled {
+	if svr.config.IsAPIEnabled(config.AdminAPIType) {
 		// Admin endpoints to check and set EigenDA backend used for dispersal
 		r.HandleFunc("/admin/eigenda-dispersal-backend", withLogging(svr.handleGetEigenDADispersalBackend, svr.log)).Methods("GET")
 		r.HandleFunc("/admin/eigenda-dispersal-backend", withLogging(svr.handleSetEigenDADispersalBackend, svr.log)).Methods("PUT")

--- a/server/routing.go
+++ b/server/routing.go
@@ -88,9 +88,9 @@ func (svr *Server) RegisterRoutes(r *mux.Router) {
 
 	// Only register admin endpoints if explicitly enabled in configuration
 	if svr.config.AdminEndpointsEnabled {
-		// Admin endpoints to check and set V2 dispersal
-		r.HandleFunc("/admin/v2-dispersal", withLogging(svr.handleGetDisperseToV2, svr.log)).Methods("GET")
-		r.HandleFunc("/admin/v2-dispersal", withLogging(svr.handleSetDisperseToV2, svr.log)).Methods("PUT")
+		// Admin endpoints to check and set EigenDA backend used for dispersal
+		r.HandleFunc("/admin/eigenda-dispersal-backend", withLogging(svr.handleGetEigenDADispersalBackend, svr.log)).Methods("GET")
+		r.HandleFunc("/admin/eigenda-dispersal-backend", withLogging(svr.handleSetEigenDADispersalBackend, svr.log)).Methods("PUT")
 	}
 }
 

--- a/server/routing.go
+++ b/server/routing.go
@@ -85,6 +85,13 @@ func (svr *Server) RegisterRoutes(r *mux.Router) {
 	)
 
 	r.HandleFunc("/health", withLogging(svr.handleHealth, svr.log)).Methods("GET")
+
+	// Only register admin endpoints if explicitly enabled in configuration
+	if svr.config.AdminEndpointsEnabled {
+		// Admin endpoints to check and set V2 dispersal
+		r.HandleFunc("/admin/v2-dispersal", withLogging(svr.handleGetDisperseToV2, svr.log)).Methods("GET")
+		r.HandleFunc("/admin/v2-dispersal", withLogging(svr.handleSetDisperseToV2, svr.log)).Methods("PUT")
+	}
 }
 
 func notCommitmentModeStandard(r *http.Request, _ *mux.RouteMatch) bool {

--- a/server/server.go
+++ b/server/server.go
@@ -30,6 +30,7 @@ type Server struct {
 	m          metrics.Metricer
 	httpServer *http.Server
 	listener   net.Listener
+	config     config.ServerConfig
 }
 
 func NewServer(
@@ -44,6 +45,7 @@ func NewServer(
 		log:      log,
 		endpoint: endpoint,
 		sm:       sm,
+		config:   cfg,
 		httpServer: &http.Server{
 			Addr:              endpoint,
 			ReadHeaderTimeout: 10 * time.Second,


### PR DESCRIPTION
- closes DAINT-420
    -  [link](https://linear.app/eigenlabs/issue/DAINT-420/create-admin-http-endpoints-to-get-and-set-dispersetov2)
- closes DAINT-389
    - [link](https://linear.app/eigenlabs/issue/DAINT-389/docs-document-v2-migration)

## Flag changes
- adds new flag 
```
		&cli.BoolFlag{
			Name:     AdminEndpointsEnabledFlagName,
			Usage:    "Enable administrative HTTP endpoints for runtime configuration",
			Value:    false,
			EnvVars:  common.PrefixEnvVar(envPrefix, "ADMIN_ENDPOINTS_ENABLED"),
			Category: category,
		},
```
