### PR TITLE
chore!: Clean up put retries

### DIFF
--- a/common/client_config_v1.go
+++ b/common/client_config_v1.go
@@ -13,5 +13,9 @@ import (
 type ClientConfigV1 struct {
 	EdaClientCfg     clients.EigenDAClientConfig
 	MaxBlobSizeBytes uint64
-	PutRetries       uint
+	// Determines number of times to try blob dispersals:
+	// - If > 0: Try up to that many times total (first attempt + up to N-1 retries)
+	// - If = 0: Try only once (no retries)
+	// - If < 0: Try indefinitely until success
+	PutRetries int
 }

--- a/common/client_config_v1.go
+++ b/common/client_config_v1.go
@@ -13,9 +13,9 @@ import (
 type ClientConfigV1 struct {
 	EdaClientCfg     clients.EigenDAClientConfig
 	MaxBlobSizeBytes uint64
-	// Determines number of times to try blob dispersals:
-	// - If > 0: Try up to that many times total (first attempt + up to N-1 retries)
-	// - If = 0: Try only once (no retries)
-	// - If < 0: Try indefinitely until success
-	PutRetries int
+	// Number of times to try blob dispersals:
+	// - If > 0: Try N times total
+	// - If < 0: Retry indefinitely until success
+	// - If = 0: Not permitted
+	PutTries int
 }

--- a/common/client_config_v2.go
+++ b/common/client_config_v2.go
@@ -16,7 +16,12 @@ type ClientConfigV2 struct {
 
 	// The following fields are not needed directly by any underlying components. Rather, these are configuration
 	// values required by the proxy itself.
-	PutRetries                 uint
+
+	// Determines number of times to try blob dispersals:
+	// - If > 0: Try up to that many times total (first attempt + up to N-1 retries)
+	// - If = 0: Try only once (no retries)
+	// - If < 0: Try indefinitely until success
+	PutRetries                 int
 	MaxBlobSizeBytes           uint64
 	EigenDACertVerifierAddress string
 }

--- a/common/client_config_v2.go
+++ b/common/client_config_v2.go
@@ -17,11 +17,11 @@ type ClientConfigV2 struct {
 	// The following fields are not needed directly by any underlying components. Rather, these are configuration
 	// values required by the proxy itself.
 
-	// Determines number of times to try blob dispersals:
-	// - If > 0: Try up to that many times total (first attempt + up to N-1 retries)
-	// - If = 0: Try only once (no retries)
-	// - If < 0: Try indefinitely until success
-	PutRetries                 int
+	// Number of times to try blob dispersals:
+	// - If > 0: Try N times total
+	// - If < 0: Retry indefinitely until success
+	// - If = 0: Not permitted
+	PutTries                   int
 	MaxBlobSizeBytes           uint64
 	EigenDACertVerifierAddress string
 }

--- a/common/client_config_v2.go
+++ b/common/client_config_v2.go
@@ -44,5 +44,9 @@ func (cfg *ClientConfigV2) Check() error {
 		return fmt.Errorf("max blob size is required for using EigenDA V2 backend")
 	}
 
+	if cfg.PutTries == 0 {
+		return fmt.Errorf("PutTries==0 is not permitted. >0 means 'try N times', <0 means 'retry indefinitely'")
+	}
+
 	return nil
 }

--- a/config/eigendaflags/cli.go
+++ b/config/eigendaflags/cli.go
@@ -65,12 +65,12 @@ func CLIFlags(envPrefix, category string) []cli.Flag {
 		&cli.DurationFlag{
 			Name: ConfirmationTimeoutFlagName,
 			Usage: `The total amount of time that the client will spend waiting for EigenDA
-			to "confirm" (include onchain) a blob after it has been dispersed. Note that
-			we stick to "confirm" here but this really means InclusionTimeout,
-			not confirmation in the sense of confirmation depth.
-			
-			If ConfirmationTimeout time passes and the blob is not yet confirmed,
-			the client will return an api.ErrorFailover to let the caller failover to EthDA.`,
+				to "confirm" (include onchain) a blob after it has been dispersed. Note that
+				we stick to "confirm" here but this really means InclusionTimeout,
+				not confirmation in the sense of confirmation depth.
+				
+				If ConfirmationTimeout time passes and the blob is not yet confirmed,
+				the client will return an api.ErrorFailover to let the caller failover to EthDA.`,
 			Value:    15 * time.Minute,
 			EnvVars:  []string{withEnvPrefix(envPrefix, "CONFIRMATION_TIMEOUT")},
 			Category: category,
@@ -151,8 +151,9 @@ func CLIFlags(envPrefix, category string) []cli.Flag {
 		// Flags that are proxy specific, and not used by the eigenda-client
 		// TODO: should we move this to a more specific category, like EIGENDA_STORE?
 		&cli.IntFlag{
-			Name:     PutRetriesFlagName,
-			Usage:    "Total number of times to try blob dispersals before serving an error response. Set to 0 for no retries (try only once), set to a negative value to retry indefinitely.",
+			Name: PutRetriesFlagName,
+			Usage: "Total number of times to try blob dispersals before serving an error response." +
+				">0 = try dispersal that many times. <0 = retry indefinitely. 0 is not permitted (causes startup error).",
 			Value:    3,
 			EnvVars:  []string{withEnvPrefix(envPrefix, "PUT_RETRIES")},
 			Category: category,
@@ -160,8 +161,8 @@ func CLIFlags(envPrefix, category string) []cli.Flag {
 		&cli.StringFlag{
 			Name: MaxBlobLengthFlagName,
 			Usage: `Maximum blob length to be written or read from EigenDA. Determines the number of SRS points
-						loaded into memory for KZG commitments. Example units: '30MiB', '4Kb', '30MB'. Maximum size
-						slightly exceeds 1GB.`,
+							loaded into memory for KZG commitments. Example units: '30MiB', '4Kb', '30MB'. Maximum size
+							slightly exceeds 1GB.`,
 			EnvVars:  []string{withEnvPrefix(envPrefix, "MAX_BLOB_LENGTH")},
 			Value:    "16MiB",
 			Category: category,
@@ -181,7 +182,7 @@ func ParseMaxBlobLength(input string) (uint64, error) {
 	if numBytes > MaxAllowedBlobSize {
 		return 0, fmt.Errorf(
 			`excluding disperser constraints on max blob size, SRS points constrain the maxBlobLength 
-					configuration parameter to be less than than %d bytes`,
+						configuration parameter to be less than than %d bytes`,
 			MaxAllowedBlobSize,
 		)
 	}
@@ -202,7 +203,7 @@ func ReadClientConfigV1(ctx *cli.Context) (common.ClientConfigV1, error) {
 	return common.ClientConfigV1{
 		EdaClientCfg:     eigenDAClientConfig,
 		MaxBlobSizeBytes: maxBlobLengthBytes,
-		PutRetries:       ctx.Int(PutRetriesFlagName),
+		PutTries:         ctx.Int(PutRetriesFlagName),
 	}, nil
 }
 

--- a/config/eigendaflags/cli.go
+++ b/config/eigendaflags/cli.go
@@ -150,9 +150,9 @@ func CLIFlags(envPrefix, category string) []cli.Flag {
 		},
 		// Flags that are proxy specific, and not used by the eigenda-client
 		// TODO: should we move this to a more specific category, like EIGENDA_STORE?
-		&cli.UintFlag{
+		&cli.IntFlag{
 			Name:     PutRetriesFlagName,
-			Usage:    "Number of times to retry blob dispersals.",
+			Usage:    "Total number of times to try blob dispersals before serving an error response. Set to 0 for no retries (try only once), set to a negative value to retry indefinitely.",
 			Value:    3,
 			EnvVars:  []string{withEnvPrefix(envPrefix, "PUT_RETRIES")},
 			Category: category,
@@ -202,7 +202,7 @@ func ReadClientConfigV1(ctx *cli.Context) (common.ClientConfigV1, error) {
 	return common.ClientConfigV1{
 		EdaClientCfg:     eigenDAClientConfig,
 		MaxBlobSizeBytes: maxBlobLengthBytes,
-		PutRetries:       ctx.Uint(PutRetriesFlagName),
+		PutRetries:       ctx.Int(PutRetriesFlagName),
 	}, nil
 }
 

--- a/config/eigendaflags/cli.go
+++ b/config/eigendaflags/cli.go
@@ -65,12 +65,12 @@ func CLIFlags(envPrefix, category string) []cli.Flag {
 		&cli.DurationFlag{
 			Name: ConfirmationTimeoutFlagName,
 			Usage: `The total amount of time that the client will spend waiting for EigenDA
-				to "confirm" (include onchain) a blob after it has been dispersed. Note that
-				we stick to "confirm" here but this really means InclusionTimeout,
-				not confirmation in the sense of confirmation depth.
-				
-				If ConfirmationTimeout time passes and the blob is not yet confirmed,
-				the client will return an api.ErrorFailover to let the caller failover to EthDA.`,
+			to "confirm" (include onchain) a blob after it has been dispersed. Note that
+			we stick to "confirm" here but this really means InclusionTimeout,
+			not confirmation in the sense of confirmation depth.
+			
+			If ConfirmationTimeout time passes and the blob is not yet confirmed,
+			the client will return an api.ErrorFailover to let the caller failover to EthDA.`,
 			Value:    15 * time.Minute,
 			EnvVars:  []string{withEnvPrefix(envPrefix, "CONFIRMATION_TIMEOUT")},
 			Category: category,
@@ -161,8 +161,8 @@ func CLIFlags(envPrefix, category string) []cli.Flag {
 		&cli.StringFlag{
 			Name: MaxBlobLengthFlagName,
 			Usage: `Maximum blob length to be written or read from EigenDA. Determines the number of SRS points
-							loaded into memory for KZG commitments. Example units: '30MiB', '4Kb', '30MB'. Maximum size
-							slightly exceeds 1GB.`,
+						loaded into memory for KZG commitments. Example units: '30MiB', '4Kb', '30MB'. Maximum size
+						slightly exceeds 1GB.`,
 			EnvVars:  []string{withEnvPrefix(envPrefix, "MAX_BLOB_LENGTH")},
 			Value:    "16MiB",
 			Category: category,
@@ -182,7 +182,7 @@ func ParseMaxBlobLength(input string) (uint64, error) {
 	if numBytes > MaxAllowedBlobSize {
 		return 0, fmt.Errorf(
 			`excluding disperser constraints on max blob size, SRS points constrain the maxBlobLength 
-						configuration parameter to be less than than %d bytes`,
+					configuration parameter to be less than than %d bytes`,
 			MaxAllowedBlobSize,
 		)
 	}

--- a/config/proxy_config_test.go
+++ b/config/proxy_config_test.go
@@ -34,6 +34,7 @@ func validCfg() ProxyConfig {
 				SvcManagerAddr:               "0x00000000069",
 				EthRpcUrl:                    "http://localhosts",
 			},
+			PutTries: 3,
 		},
 		VerifierConfigV1: verify.Config{
 			VerifyCerts:          false,
@@ -61,6 +62,7 @@ func validCfg() ProxyConfig {
 			},
 			EigenDACertVerifierAddress: "0x0000000000032443134",
 			MaxBlobSizeBytes:           maxBlobLengthBytes,
+			PutTries:                   3,
 		},
 		StorageConfig: store.Config{
 			BackendsToEnable: []common.EigenDABackend{common.V1EigenDABackend, common.V2EigenDABackend},

--- a/config/v2/eigendaflags/cli.go
+++ b/config/v2/eigendaflags/cli.go
@@ -76,8 +76,9 @@ func CLIFlags(envPrefix, category string) []cli.Flag {
 			Required: false,
 		},
 		&cli.IntFlag{
-			Name:     PutRetriesFlagName,
-			Usage:    "Total number of times to try blob dispersals before serving an error response. Set to 0 for no retries (try only once), set to a negative value to retry indefinitely.",
+			Name: PutRetriesFlagName,
+			Usage: "Total number of times to try blob dispersals before serving an error response." +
+				">0 = try dispersal that many times. <0 = retry indefinitely. 0 is not permitted (causes startup error).",
 			Value:    3,
 			EnvVars:  []string{withEnvPrefix(envPrefix, "PUT_RETRIES")},
 			Category: category,
@@ -170,7 +171,7 @@ func ReadClientConfigV2(ctx *cli.Context) (common.ClientConfigV2, error) {
 		DisperserClientCfg:         disperserConfig,
 		PayloadDisperserCfg:        readPayloadDisperserCfg(ctx),
 		RelayPayloadRetrieverCfg:   readRetrievalConfig(ctx),
-		PutRetries:                 ctx.Int(PutRetriesFlagName),
+		PutTries:                   ctx.Int(PutRetriesFlagName),
 		MaxBlobSizeBytes:           maxBlobLengthBytes,
 		EigenDACertVerifierAddress: ctx.String(CertVerifierAddrFlagName),
 	}, nil

--- a/config/v2/eigendaflags/cli.go
+++ b/config/v2/eigendaflags/cli.go
@@ -75,9 +75,9 @@ func CLIFlags(envPrefix, category string) []cli.Flag {
 			Category: category,
 			Required: false,
 		},
-		&cli.UintFlag{
+		&cli.IntFlag{
 			Name:     PutRetriesFlagName,
-			Usage:    "Number of times to retry blob dispersals before serving an error response.",
+			Usage:    "Total number of times to try blob dispersals before serving an error response. Set to 0 for no retries (try only once), set to a negative value to retry indefinitely.",
 			Value:    3,
 			EnvVars:  []string{withEnvPrefix(envPrefix, "PUT_RETRIES")},
 			Category: category,
@@ -170,7 +170,7 @@ func ReadClientConfigV2(ctx *cli.Context) (common.ClientConfigV2, error) {
 		DisperserClientCfg:         disperserConfig,
 		PayloadDisperserCfg:        readPayloadDisperserCfg(ctx),
 		RelayPayloadRetrieverCfg:   readRetrievalConfig(ctx),
-		PutRetries:                 ctx.Uint(PutRetriesFlagName),
+		PutRetries:                 ctx.Int(PutRetriesFlagName),
 		MaxBlobSizeBytes:           maxBlobLengthBytes,
 		EigenDACertVerifierAddress: ctx.String(CertVerifierAddrFlagName),
 	}, nil

--- a/docs/help_out.txt
+++ b/docs/help_out.txt
@@ -39,7 +39,7 @@ GLOBAL OPTIONS:
                                                                                       loaded into memory for KZG commitments. Example units: '30MiB', '4Kb', '30MB'. Maximum size
                                                                                       slightly exceeds 1GB. (default: "16MiB") [$EIGENDA_PROXY_EIGENDA_MAX_BLOB_LENGTH]
    --eigenda.put-blob-encoding-version value                                Blob encoding version to use when writing blobs from the high-level interface. (default: 0) [$EIGENDA_PROXY_EIGENDA_PUT_BLOB_ENCODING_VERSION]
-   --eigenda.put-retries value                                              Number of times to retry blob dispersals. (default: 3) [$EIGENDA_PROXY_EIGENDA_PUT_RETRIES]
+   --eigenda.put-retries value                                              Total number of times to try blob dispersals before serving an error response. Set to 0 for no retries (try only once), set to a negative value to retry indefinitely. (default: 3) [$EIGENDA_PROXY_EIGENDA_PUT_RETRIES]
    --eigenda.response-timeout value                                         Flag used to configure the underlying disperser-client. Total time to wait for the disperseBlob call to return or disperseAuthenticatedBlob stream to finish and close. (default: 1m0s) [$EIGENDA_PROXY_EIGENDA_RESPONSE_TIMEOUT]
    --eigenda.signer-private-key-hex value                                   Hex-encoded signer private key. Used for authn/authz and rate limits on EigenDA disperser. Should not be associated with an Ethereum address holding any funds. [$EIGENDA_PROXY_EIGENDA_SIGNER_PRIVATE_KEY_HEX]
    --eigenda.status-query-retry-interval value                              Interval between retries when awaiting network blob finalization. Default is 5 seconds. (default: 5s) [$EIGENDA_PROXY_EIGENDA_STATUS_QUERY_INTERVAL]
@@ -64,7 +64,7 @@ GLOBAL OPTIONS:
    --eigenda.v2.max-blob-length value            Maximum blob length to be written or read from EigenDA. Determines the number of SRS points
                                                            loaded into memory for KZG commitments. Example units: '30MiB', '4Kb', '30MB'. Maximum size
                                                            slightly exceeds 1GB. (default: "16MiB") [$EIGENDA_PROXY_EIGENDA_V2_MAX_BLOB_LENGTH]
-   --eigenda.v2.put-retries value                Number of times to retry blob dispersals before serving an error response. (default: 3) [$EIGENDA_PROXY_EIGENDA_V2_PUT_RETRIES]
+   --eigenda.v2.put-retries value                Total number of times to try blob dispersals before serving an error response. Set to 0 for no retries (try only once), set to a negative value to retry indefinitely. (default: 3) [$EIGENDA_PROXY_EIGENDA_V2_PUT_RETRIES]
    --eigenda.v2.relay-timeout value              Timeout used when querying an individual relay for blob contents. (default: 10s) [$EIGENDA_PROXY_EIGENDA_V2_RELAY_TIMEOUT]
    --eigenda.v2.signer-payment-key-hex value     Hex-encoded signer private key. Used for authorizing payments with EigenDA disperser. Should not be associated with an Ethereum address holding any funds. [$EIGENDA_PROXY_EIGENDA_V2_SIGNER_PRIVATE_KEY_HEX]
 

--- a/docs/help_out.txt
+++ b/docs/help_out.txt
@@ -24,22 +24,22 @@ GLOBAL OPTIONS:
 
    --eigenda.confirmation-depth value                                       Number of Ethereum blocks to wait after the blob's batch has been included on-chain, before returning from PutBlob calls. Can either be a number or 'finalized'. (default: "8") [$EIGENDA_PROXY_EIGENDA_CONFIRMATION_DEPTH]
    --eigenda.confirmation-timeout value                                     The total amount of time that the client will spend waiting for EigenDA
-                                                                                to "confirm" (include onchain) a blob after it has been dispersed. Note that
-                                                                                we stick to "confirm" here but this really means InclusionTimeout,
-                                                                                not confirmation in the sense of confirmation depth.
-                                                                                
-                                                                                If ConfirmationTimeout time passes and the blob is not yet confirmed,
-                                                                                the client will return an api.ErrorFailover to let the caller failover to EthDA. (default: 15m0s) [$EIGENDA_PROXY_EIGENDA_CONFIRMATION_TIMEOUT]
+                                                                                  to "confirm" (include onchain) a blob after it has been dispersed. Note that
+                                                                                  we stick to "confirm" here but this really means InclusionTimeout,
+                                                                                  not confirmation in the sense of confirmation depth.
+                                                                                  
+                                                                                  If ConfirmationTimeout time passes and the blob is not yet confirmed,
+                                                                                  the client will return an api.ErrorFailover to let the caller failover to EthDA. (default: 15m0s) [$EIGENDA_PROXY_EIGENDA_CONFIRMATION_TIMEOUT]
    --eigenda.custom-quorum-ids value [ --eigenda.custom-quorum-ids value ]  Custom quorum IDs for writing blobs. Should not include default quorums 0 or 1. [$EIGENDA_PROXY_EIGENDA_CUSTOM_QUORUM_IDS]
    --eigenda.disable-point-verification-mode                                Disable point verification mode. This mode performs IFFT on data before writing and FFT on data after reading. Disabling requires supplying the entire blob for verification against the KZG commitment. (default: false) [$EIGENDA_PROXY_EIGENDA_DISABLE_POINT_VERIFICATION_MODE]
    --eigenda.disable-tls                                                    Disable TLS for gRPC communication with the EigenDA disperser. Default is false. (default: false) [$EIGENDA_PROXY_EIGENDA_GRPC_DISABLE_TLS]
    --eigenda.disperser-rpc value                                            RPC endpoint of the EigenDA disperser. [$EIGENDA_PROXY_EIGENDA_DISPERSER_RPC]
    --eigenda.eth-rpc value                                                  URL of the Ethereum RPC endpoint. Needed to confirm blobs landed onchain. [$EIGENDA_PROXY_EIGENDA_ETH_RPC]
    --eigenda.max-blob-length value                                          Maximum blob length to be written or read from EigenDA. Determines the number of SRS points
-                                                                                      loaded into memory for KZG commitments. Example units: '30MiB', '4Kb', '30MB'. Maximum size
-                                                                                      slightly exceeds 1GB. (default: "16MiB") [$EIGENDA_PROXY_EIGENDA_MAX_BLOB_LENGTH]
+                                                                                        loaded into memory for KZG commitments. Example units: '30MiB', '4Kb', '30MB'. Maximum size
+                                                                                        slightly exceeds 1GB. (default: "16MiB") [$EIGENDA_PROXY_EIGENDA_MAX_BLOB_LENGTH]
    --eigenda.put-blob-encoding-version value                                Blob encoding version to use when writing blobs from the high-level interface. (default: 0) [$EIGENDA_PROXY_EIGENDA_PUT_BLOB_ENCODING_VERSION]
-   --eigenda.put-retries value                                              Total number of times to try blob dispersals before serving an error response. Set to 0 for no retries (try only once), set to a negative value to retry indefinitely. (default: 3) [$EIGENDA_PROXY_EIGENDA_PUT_RETRIES]
+   --eigenda.put-retries value                                              Total number of times to try blob dispersals before serving an error response. Value meanings: 1 = try only once (no retries), 2 = try twice (initial try + 1 retry), etc. Negative values = retry indefinitely. Zero is not allowed (causes startup error). (default: 3) [$EIGENDA_PROXY_EIGENDA_PUT_RETRIES]
    --eigenda.response-timeout value                                         Flag used to configure the underlying disperser-client. Total time to wait for the disperseBlob call to return or disperseAuthenticatedBlob stream to finish and close. (default: 1m0s) [$EIGENDA_PROXY_EIGENDA_RESPONSE_TIMEOUT]
    --eigenda.signer-private-key-hex value                                   Hex-encoded signer private key. Used for authn/authz and rate limits on EigenDA disperser. Should not be associated with an Ethereum address holding any funds. [$EIGENDA_PROXY_EIGENDA_SIGNER_PRIVATE_KEY_HEX]
    --eigenda.status-query-retry-interval value                              Interval between retries when awaiting network blob finalization. Default is 5 seconds. (default: 5s) [$EIGENDA_PROXY_EIGENDA_STATUS_QUERY_INTERVAL]
@@ -64,7 +64,7 @@ GLOBAL OPTIONS:
    --eigenda.v2.max-blob-length value            Maximum blob length to be written or read from EigenDA. Determines the number of SRS points
                                                            loaded into memory for KZG commitments. Example units: '30MiB', '4Kb', '30MB'. Maximum size
                                                            slightly exceeds 1GB. (default: "16MiB") [$EIGENDA_PROXY_EIGENDA_V2_MAX_BLOB_LENGTH]
-   --eigenda.v2.put-retries value                Total number of times to try blob dispersals before serving an error response. Set to 0 for no retries (try only once), set to a negative value to retry indefinitely. (default: 3) [$EIGENDA_PROXY_EIGENDA_V2_PUT_RETRIES]
+   --eigenda.v2.put-retries value                Total number of times to try blob dispersals before serving an error response. Value meanings: 1 = try only once (no retries), 2 = try twice (initial try + 1 retry), etc. Negative values = retry indefinitely. Zero is not allowed (causes startup error). (default: 3) [$EIGENDA_PROXY_EIGENDA_V2_PUT_RETRIES]
    --eigenda.v2.relay-timeout value              Timeout used when querying an individual relay for blob contents. (default: 10s) [$EIGENDA_PROXY_EIGENDA_V2_RELAY_TIMEOUT]
    --eigenda.v2.signer-payment-key-hex value     Hex-encoded signer private key. Used for authorizing payments with EigenDA disperser. Should not be associated with an Ethereum address holding any funds. [$EIGENDA_PROXY_EIGENDA_V2_SIGNER_PRIVATE_KEY_HEX]
 

--- a/docs/help_out.txt
+++ b/docs/help_out.txt
@@ -24,22 +24,22 @@ GLOBAL OPTIONS:
 
    --eigenda.confirmation-depth value                                       Number of Ethereum blocks to wait after the blob's batch has been included on-chain, before returning from PutBlob calls. Can either be a number or 'finalized'. (default: "8") [$EIGENDA_PROXY_EIGENDA_CONFIRMATION_DEPTH]
    --eigenda.confirmation-timeout value                                     The total amount of time that the client will spend waiting for EigenDA
-                                                                                  to "confirm" (include onchain) a blob after it has been dispersed. Note that
-                                                                                  we stick to "confirm" here but this really means InclusionTimeout,
-                                                                                  not confirmation in the sense of confirmation depth.
-                                                                                  
-                                                                                  If ConfirmationTimeout time passes and the blob is not yet confirmed,
-                                                                                  the client will return an api.ErrorFailover to let the caller failover to EthDA. (default: 15m0s) [$EIGENDA_PROXY_EIGENDA_CONFIRMATION_TIMEOUT]
+                                                                                to "confirm" (include onchain) a blob after it has been dispersed. Note that
+                                                                                we stick to "confirm" here but this really means InclusionTimeout,
+                                                                                not confirmation in the sense of confirmation depth.
+                                                                                
+                                                                                If ConfirmationTimeout time passes and the blob is not yet confirmed,
+                                                                                the client will return an api.ErrorFailover to let the caller failover to EthDA. (default: 15m0s) [$EIGENDA_PROXY_EIGENDA_CONFIRMATION_TIMEOUT]
    --eigenda.custom-quorum-ids value [ --eigenda.custom-quorum-ids value ]  Custom quorum IDs for writing blobs. Should not include default quorums 0 or 1. [$EIGENDA_PROXY_EIGENDA_CUSTOM_QUORUM_IDS]
    --eigenda.disable-point-verification-mode                                Disable point verification mode. This mode performs IFFT on data before writing and FFT on data after reading. Disabling requires supplying the entire blob for verification against the KZG commitment. (default: false) [$EIGENDA_PROXY_EIGENDA_DISABLE_POINT_VERIFICATION_MODE]
    --eigenda.disable-tls                                                    Disable TLS for gRPC communication with the EigenDA disperser. Default is false. (default: false) [$EIGENDA_PROXY_EIGENDA_GRPC_DISABLE_TLS]
    --eigenda.disperser-rpc value                                            RPC endpoint of the EigenDA disperser. [$EIGENDA_PROXY_EIGENDA_DISPERSER_RPC]
    --eigenda.eth-rpc value                                                  URL of the Ethereum RPC endpoint. Needed to confirm blobs landed onchain. [$EIGENDA_PROXY_EIGENDA_ETH_RPC]
    --eigenda.max-blob-length value                                          Maximum blob length to be written or read from EigenDA. Determines the number of SRS points
-                                                                                        loaded into memory for KZG commitments. Example units: '30MiB', '4Kb', '30MB'. Maximum size
-                                                                                        slightly exceeds 1GB. (default: "16MiB") [$EIGENDA_PROXY_EIGENDA_MAX_BLOB_LENGTH]
+                                                                                      loaded into memory for KZG commitments. Example units: '30MiB', '4Kb', '30MB'. Maximum size
+                                                                                      slightly exceeds 1GB. (default: "16MiB") [$EIGENDA_PROXY_EIGENDA_MAX_BLOB_LENGTH]
    --eigenda.put-blob-encoding-version value                                Blob encoding version to use when writing blobs from the high-level interface. (default: 0) [$EIGENDA_PROXY_EIGENDA_PUT_BLOB_ENCODING_VERSION]
-   --eigenda.put-retries value                                              Total number of times to try blob dispersals before serving an error response. Value meanings: 1 = try only once (no retries), 2 = try twice (initial try + 1 retry), etc. Negative values = retry indefinitely. Zero is not allowed (causes startup error). (default: 3) [$EIGENDA_PROXY_EIGENDA_PUT_RETRIES]
+   --eigenda.put-retries value                                              Total number of times to try blob dispersals before serving an error response.>0 = try dispersal that many times. <0 = retry indefinitely. 0 is not permitted (causes startup error). (default: 3) [$EIGENDA_PROXY_EIGENDA_PUT_RETRIES]
    --eigenda.response-timeout value                                         Flag used to configure the underlying disperser-client. Total time to wait for the disperseBlob call to return or disperseAuthenticatedBlob stream to finish and close. (default: 1m0s) [$EIGENDA_PROXY_EIGENDA_RESPONSE_TIMEOUT]
    --eigenda.signer-private-key-hex value                                   Hex-encoded signer private key. Used for authn/authz and rate limits on EigenDA disperser. Should not be associated with an Ethereum address holding any funds. [$EIGENDA_PROXY_EIGENDA_SIGNER_PRIVATE_KEY_HEX]
    --eigenda.status-query-retry-interval value                              Interval between retries when awaiting network blob finalization. Default is 5 seconds. (default: 5s) [$EIGENDA_PROXY_EIGENDA_STATUS_QUERY_INTERVAL]
@@ -64,7 +64,7 @@ GLOBAL OPTIONS:
    --eigenda.v2.max-blob-length value            Maximum blob length to be written or read from EigenDA. Determines the number of SRS points
                                                            loaded into memory for KZG commitments. Example units: '30MiB', '4Kb', '30MB'. Maximum size
                                                            slightly exceeds 1GB. (default: "16MiB") [$EIGENDA_PROXY_EIGENDA_V2_MAX_BLOB_LENGTH]
-   --eigenda.v2.put-retries value                Total number of times to try blob dispersals before serving an error response. Value meanings: 1 = try only once (no retries), 2 = try twice (initial try + 1 retry), etc. Negative values = retry indefinitely. Zero is not allowed (causes startup error). (default: 3) [$EIGENDA_PROXY_EIGENDA_V2_PUT_RETRIES]
+   --eigenda.v2.put-retries value                Total number of times to try blob dispersals before serving an error response.>0 = try dispersal that many times. <0 = retry indefinitely. 0 is not permitted (causes startup error). (default: 3) [$EIGENDA_PROXY_EIGENDA_V2_PUT_RETRIES]
    --eigenda.v2.relay-timeout value              Timeout used when querying an individual relay for blob contents. (default: 10s) [$EIGENDA_PROXY_EIGENDA_V2_RELAY_TIMEOUT]
    --eigenda.v2.signer-payment-key-hex value     Hex-encoded signer private key. Used for authorizing payments with EigenDA disperser. Should not be associated with an Ethereum address holding any funds. [$EIGENDA_PROXY_EIGENDA_V2_SIGNER_PRIVATE_KEY_HEX]
 

--- a/store/generated_key/utils/store_utils.go
+++ b/store/generated_key/utils/store_utils.go
@@ -1,22 +1,14 @@
 package utils
 
-// MapPutRetries converts a user-provided PutRetries value to a value for the retry-go library.
-// This function handles the translation between the user-facing API and the internal retry-go library.
-// IMPORTANT: In retry-go, the "attempts" parameter represents the TOTAL number of attempts, including the first try.
-//
-// The mapping works as follows:
-// - putRetries > 0: Maps to that value directly (e.g., 3 means "try once, then retry twice if needed")
-// - putRetries = 0: Maps to 1 (means "try once with no retries"). This mapping exists to provide sane default behavior
-// - putRetries < 0: Maps to 0 (means "retry indefinitely until success")
-//
-// Note: This function is used by both v1 and v2 EigenDA backends to maintain consistent retry behavior.
-func MapPutRetries(putRetries int) uint {
-	switch {
-	case putRetries > 0:
-		return uint(putRetries)
-	case putRetries == 0:
-		return 1
-	default: // putRetries < 0
-		return 0 // 0 means "retry forever" in the retry-go library
+// ConvertToRetryGoAttempts converts the user-facing PutTries value to retry-go's "attempts" semantic.
+// In retry-go:
+// - 0 "attempts" means retry forever (corresponds to our negative PutTries)
+// - >0 "attempts" means try that many times total (corresponds to our PutTries values)
+// Note: This function doesn't handle the PutTries=0 case, since 0 isn't a valid configuration, and this is checked
+// at construction time
+func ConvertToRetryGoAttempts(putTries int) uint {
+	if putTries < 0 {
+		return 0
 	}
+	return uint(putTries)
 }

--- a/store/generated_key/utils/store_utils.go
+++ b/store/generated_key/utils/store_utils.go
@@ -1,0 +1,22 @@
+package utils
+
+// MapPutRetries converts a user-provided PutRetries value to a value for the retry-go library.
+// This function handles the translation between the user-facing API and the internal retry-go library.
+// IMPORTANT: In retry-go, the "attempts" parameter represents the TOTAL number of attempts, including the first try.
+//
+// The mapping works as follows:
+// - putRetries > 0: Maps to that value directly (e.g., 3 means "try once, then retry twice if needed")
+// - putRetries = 0: Maps to 1 (means "try once with no retries"). This mapping exists to provide sane default behavior
+// - putRetries < 0: Maps to 0 (means "retry indefinitely until success")
+//
+// Note: This function is used by both v1 and v2 EigenDA backends to maintain consistent retry behavior.
+func MapPutRetries(putRetries int) uint {
+	switch {
+	case putRetries > 0:
+		return uint(putRetries)
+	case putRetries == 0:
+		return 1
+	default: // putRetries < 0
+		return 0 // 0 means "retry forever" in the retry-go library
+	}
+}

--- a/store/generated_key/v2/eigenda.go
+++ b/store/generated_key/v2/eigenda.go
@@ -20,18 +20,12 @@ import (
 
 // Store does storage interactions and verifications for blobs with the EigenDA V2 protocol.
 type Store struct {
-	// putRetries specifies the total number of times to try dispersing a blob.
-	// This value comes from utils.MapPutRetries() and is passed directly to retry-go.
-	//
-	// IMPORTANT: In retry-go, this parameter means:
-	// - Value of 0: Try indefinitely until success
-	// - Value of 1: Try once with no retries
-	// - Value > 1: Try up to this many times total (first try + up to N-1 retries)
-	//
-	// Users should NEVER set this field directly. Always use NewStore(), which correctly maps from the user-friendly
-	// int values to the internal uint values required by the retry-go library.
-	putRetries uint
-	log        logging.Logger
+	// Number of times to try blob dispersals:
+	// - If > 0: Try N times total
+	// - If < 0: Retry indefinitely until success
+	// - If = 0: Not permitted
+	putTries int
+	log      logging.Logger
 
 	disperser *payloaddispersal.PayloadDisperser
 	retriever clients.PayloadRetriever
@@ -42,17 +36,22 @@ var _ common.GeneratedKeyStore = (*Store)(nil)
 
 func NewStore(
 	log logging.Logger,
-	putRetries int,
+	putTries int,
 	disperser *payloaddispersal.PayloadDisperser,
 	retriever clients.PayloadRetriever,
 	verifier clients.ICertVerifier,
 ) (*Store, error) {
+	if putTries == 0 {
+		return nil, fmt.Errorf(
+			"putTries==0 is not permitted. >0 means 'try N times', <0 means 'retry indefinitely'")
+	}
+
 	return &Store{
-		log:        log,
-		putRetries: utils.MapPutRetries(putRetries),
-		disperser:  disperser,
-		retriever:  retriever,
-		verifier:   verifier,
+		log:       log,
+		putTries:  putTries,
+		disperser: disperser,
+		retriever: retriever,
+		verifier:  verifier,
 	}, nil
 }
 
@@ -114,7 +113,9 @@ func (e Store) Put(ctx context.Context, value []byte) ([]byte, error) {
 		// only return the last error. If it is an api.ErrorFailover, then the handler will convert
 		// it to an http 503 to signify to the client (batcher) to failover to ethda b/c eigenda is temporarily down.
 		retry.LastErrorOnly(true),
-		retry.Attempts(e.putRetries),
+		// retry.Attempts uses different semantics than our config field. ConvertToRetryGoAttempts converts between
+		// these two semantics.
+		retry.Attempts(utils.ConvertToRetryGoAttempts(e.putTries)),
 	)
 	if err != nil {
 		// TODO: we will want to filter for errors here and return a 503 when needed, i.e. when dispersal itself failed,

--- a/store/storage_manager_builder.go
+++ b/store/storage_manager_builder.go
@@ -269,12 +269,12 @@ func (smb *StorageManagerBuilder) buildEigenDAV1Backend(ctx context.Context) (co
 		client,
 		verifier,
 		smb.log,
-		&eigenda.StoreConfig{
-			MaxBlobSizeBytes:     smb.v1ClientCfg.MaxBlobSizeBytes,
-			EthConfirmationDepth: smb.v1VerifierCfg.EthConfirmationDepth,
-			StatusQueryTimeout:   smb.v1ClientCfg.EdaClientCfg.StatusQueryTimeout,
-			PutRetries:           smb.v1ClientCfg.PutRetries,
-		},
+		eigenda.NewStoreConfig(
+			smb.v1ClientCfg.MaxBlobSizeBytes,
+			smb.v1VerifierCfg.EthConfirmationDepth,
+			smb.v1ClientCfg.EdaClientCfg.StatusQueryTimeout,
+			smb.v1ClientCfg.PutRetries,
+		),
 	)
 }
 

--- a/store/storage_manager_builder.go
+++ b/store/storage_manager_builder.go
@@ -237,12 +237,17 @@ func (smb *StorageManagerBuilder) buildEigenDAV2Backend(ctx context.Context) (co
 		return nil, fmt.Errorf("build payload disperser: %w", err)
 	}
 
-	return eigenda_v2.NewStore(
+	eigenDAV2Store, err := eigenda_v2.NewStore(
 		smb.log,
-		smb.v2ClientCfg.PutRetries,
+		smb.v2ClientCfg.PutTries,
 		payloadDisperser,
 		relayPayloadRetriever,
 		certVerifier)
+	if err != nil {
+		return nil, fmt.Errorf("create v2 store: %w", err)
+	}
+
+	return eigenDAV2Store, nil
 }
 
 // buildEigenDAV1Backend ... Builds EigenDA V1 storage backend
@@ -270,16 +275,21 @@ func (smb *StorageManagerBuilder) buildEigenDAV1Backend(ctx context.Context) (co
 		return nil, err
 	}
 
+	storeConfig, err := eigenda.NewStoreConfig(
+		smb.v1ClientCfg.MaxBlobSizeBytes,
+		smb.v1VerifierCfg.EthConfirmationDepth,
+		smb.v1ClientCfg.EdaClientCfg.StatusQueryTimeout,
+		smb.v1ClientCfg.PutTries,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create v1 store config: %w", err)
+	}
+
 	return eigenda.NewStore(
 		client,
 		verifier,
 		smb.log,
-		eigenda.NewStoreConfig(
-			smb.v1ClientCfg.MaxBlobSizeBytes,
-			smb.v1VerifierCfg.EthConfirmationDepth,
-			smb.v1ClientCfg.EdaClientCfg.StatusQueryTimeout,
-			smb.v1ClientCfg.PutRetries,
-		),
+		storeConfig,
 	)
 }
 

--- a/testutils/setup.go
+++ b/testutils/setup.go
@@ -285,7 +285,7 @@ func BuildTestSuiteConfig(testCfg TestConfig) config.AppConfig {
 				SvcManagerAddr:           svcManagerAddress,
 			},
 			MaxBlobSizeBytes: maxBlobLengthBytes,
-			PutRetries:       3,
+			PutTries:         3,
 		},
 		VerifierConfigV1: verify.Config{
 			VerifyCerts:          false,
@@ -327,7 +327,7 @@ func BuildTestSuiteConfig(testCfg TestConfig) config.AppConfig {
 				PayloadClientConfig: payloadClientConfig,
 				RelayTimeout:        5 * time.Second,
 			},
-			PutRetries:                 3,
+			PutTries:                   3,
 			MaxBlobSizeBytes:           maxBlobLengthBytes,
 			EigenDACertVerifierAddress: certVerifierAddress,
 		},


### PR DESCRIPTION
- closes DAINT-419
    - [link](https://linear.app/eigenlabs/issue/DAINT-419/make-putretries-configuration-more-user-friendly) 

## Flag changes

- `PUT_RETRIES` for both v1 and v2 flags is now an `int` instead of a `uint`, to support more intuitive configuration (old logic interprets 0 to mean retry forever)
```
		&cli.IntFlag{
			Name: PutRetriesFlagName,
			Usage: "Total number of times to try blob dispersals before serving an error response." +
				">0 = try dispersal that many times. <0 = retry indefinitely. 0 is not permitted (causes startup error).",
			Value:    3,
			EnvVars:  []string{withEnvPrefix(envPrefix, "PUT_RETRIES")},
			Category: category,
		},
```
- This is *technically* a breaking change, in case anyone was relying on the old behavior where config value `0` yields infinite retries. Practically, my guess would be that no one is relying on this behavior, but it's worth noting