### PR TITLE
feat: Remove user facing load g2 option

### DIFF
--- a/.env.exampleV1AndV2.holesky
+++ b/.env.exampleV1AndV2.holesky
@@ -124,8 +124,6 @@ EIGENDA_PROXY_EIGENDA_TARGET_KZG_G2_PATH=resources/g2.point
 # Path to g2.trailing.point file
 EIGENDA_PROXY_EIGENDA_TARGET_KZG_G2_TRAILING_PATH=resources/g2.trailing.point
 
-# Whether to read in G2 SRS points
-EIGENDA_PROXY_EIGENDA_READ_G2_POINTS=true
 
 # Whether to verify certificates received from EigenDA disperser
 EIGENDA_PROXY_EIGENDA_CERT_VERIFICATION_DISABLED=false

--- a/.env.exampleV2.holesky
+++ b/.env.exampleV2.holesky
@@ -70,8 +70,6 @@ EIGENDA_PROXY_EIGENDA_TARGET_KZG_G2_PATH=resources/g2.point
 # Path to g2.trailing.point file
 EIGENDA_PROXY_EIGENDA_TARGET_KZG_G2_TRAILING_PATH=resources/g2.trailing.point
 
-# Whether to read in G2 SRS points
-EIGENDA_PROXY_EIGENDA_READ_G2_POINTS=true
 
 # Whether to verify certificates received from EigenDA disperser
 EIGENDA_PROXY_EIGENDA_CERT_VERIFICATION_DISABLED=false

--- a/docs/help_out.txt
+++ b/docs/help_out.txt
@@ -74,7 +74,6 @@ GLOBAL OPTIONS:
    --eigenda.g1-path value           path to g1.point file. (default: "resources/g1.point") [$EIGENDA_PROXY_EIGENDA_TARGET_KZG_G1_PATH]
    --eigenda.g2-path value           path to g2.point file. (default: "resources/g2.point") [$EIGENDA_PROXY_EIGENDA_TARGET_KZG_G2_PATH]
    --eigenda.g2-path-trailing value  path to g2.trailing.point file. (default: "resources/g2.trailing.point") [$EIGENDA_PROXY_EIGENDA_TARGET_KZG_G2_TRAILING_PATH]
-   --eigenda.read-g2-points          Whether to read in G2 SRS points. (default: false) [$EIGENDA_PROXY_EIGENDA_READ_G2_POINTS]
 
    Logging
 

--- a/store/storage_manager_builder.go
+++ b/store/storage_manager_builder.go
@@ -193,9 +193,14 @@ func (smb *StorageManagerBuilder) buildSecondaries(
 
 // buildEigenDAV2Backend ... Builds EigenDA V2 storage backend
 func (smb *StorageManagerBuilder) buildEigenDAV2Backend(ctx context.Context) (common.GeneratedKeyStore, error) {
-	// TODO: Figure out how to better manage the v1 verifier
-	//  may make sense to live in some global kzg config that's passed down across EigenDA versions
-	kzgProver, err := prover.NewProver(&smb.kzgConfig, nil)
+	// This is a bit of a hack. The kzg config is used by both v1 AND v2, but the `LoadG2Points` field has special
+	// requirements. For v1, it must always be false. For v2, it must always be true. Ideally, we would modify
+	// the underlying core library to be more flexible, but that is a larger change for another time. As a stopgap, we
+	// simply set this value to whatever it needs to be prior to using it.
+	config := smb.kzgConfig
+	config.LoadG2Points = true
+
+	kzgProver, err := prover.NewProver(&config, nil)
 	if err != nil {
 		return nil, fmt.Errorf("new KZG prover: %w", err)
 	}

--- a/testutils/setup.go
+++ b/testutils/setup.go
@@ -299,7 +299,6 @@ func BuildTestSuiteConfig(testCfg TestConfig) config.AppConfig {
 			G1Path:          "../resources/g1.point",
 			G2Path:          "../resources/g2.point",
 			G2TrailingPath:  "../resources/g2.trailing.point",
-			LoadG2Points:    true,
 			CacheDir:        "../resources/SRSTables",
 			SRSOrder:        eigendaflags.SrsOrder,
 			SRSNumberToLoad: maxBlobLengthBytes / 32,

--- a/verify/cli.go
+++ b/verify/cli.go
@@ -19,7 +19,6 @@ var (
 	G2PowerOf2PathFlagNameDeprecated = withFlagPrefix("g2-power-of-2-path")
 	G2PathFlagName                   = withFlagPrefix("g2-path")
 	G2TrailingPathFlagName           = withFlagPrefix("g2-path-trailing")
-	ReadG2PointsFlagName             = withFlagPrefix("read-g2-points")
 	CachePathFlagName                = withFlagPrefix("cache-path")
 )
 
@@ -87,13 +86,6 @@ func KZGCLIFlags(envPrefix, category string) []cli.Flag {
 			Value:    "resources/g2.trailing.point",
 			Category: category,
 		},
-		&cli.BoolFlag{
-			Name:     ReadG2PointsFlagName,
-			Usage:    "Whether to read in G2 SRS points.",
-			EnvVars:  []string{withEnvPrefix(envPrefix, "READ_G2_POINTS")},
-			Value:    false,
-			Category: category,
-		},
 		&cli.StringFlag{
 			Name:     CachePathFlagName,
 			Usage:    "path to SRS tables for caching. This resource is not currently used, but needed because of the shared eigenda KZG library that we use. We will eventually fix this.",
@@ -109,11 +101,13 @@ func ReadKzgConfig(ctx *cli.Context, maxBlobSizeBytes uint64) kzg.KzgConfig {
 		G1Path:          ctx.String(G1PathFlagName),
 		G2Path:          ctx.String(G2PathFlagName),
 		G2TrailingPath:  ctx.String(G2TrailingPathFlagName),
-		LoadG2Points:    ctx.Bool(ReadG2PointsFlagName),
 		CacheDir:        ctx.String(CachePathFlagName),
 		SRSOrder:        eigendaflags.SrsOrder,
 		SRSNumberToLoad: maxBlobSizeBytes / 32,         // # of fr.Elements
 		NumWorker:       uint64(runtime.GOMAXPROCS(0)), // #nosec G115
+		// we are intentionally not setting the `LoadG2Points` field here. `LoadG2Points` has different requirements
+		// for v1 vs v2. To make things foolproof, we just set this value locally prior to use, so that it can't
+		// ever be set incorrectly.
 	}
 }
 


### PR DESCRIPTION
- Remove user facing "load g2 points" option, since it can be explicitly set correctly for each case, without user input

## Flag changes

- Deletes `ReadG2PointsFlag`. This isn't a breaking change, since a version of proxy has never been released with it.

```
		&cli.BoolFlag{
			Name:     ReadG2PointsFlagName,
			Usage:    "Whether to read in G2 SRS points.",
			EnvVars:  []string{withEnvPrefix(envPrefix, "READ_G2_POINTS")},
			Value:    false,
			Category: category,
		},
```