### PR TITLE
feat: Implement validator node blob retrieval

### DIFF
--- a/.env.exampleV1AndV2.holesky
+++ b/.env.exampleV1AndV2.holesky
@@ -86,6 +86,9 @@ EIGENDA_PROXY_EIGENDA_V2_CONTRACT_CALL_TIMEOUT=5s
 # Timeout used when querying an individual relay for blob contents
 EIGENDA_PROXY_EIGENDA_V2_RELAY_TIMEOUT=5s
 
+# Timeout used when retrieving payload chunks directly from EigenDA validators (fallback method)
+EIGENDA_PROXY_EIGENDA_V2_VALIDATOR_TIMEOUT=2m
+
 # Blob params version used when dispersing
 EIGENDA_PROXY_EIGENDA_V2_BLOB_PARAMS_VERSION=0
 
@@ -95,6 +98,12 @@ EIGENDA_PROXY_EIGENDA_V2_BLOB_PARAMS_VERSION=0
 # you only actually need to read the amount of SRS data that corresponds to the size of the largest blob that will be
 # sent, decreasing this value is a crude sort of optimization.
 EIGENDA_PROXY_EIGENDA_V2_MAX_BLOB_LENGTH=1MiB
+
+# Address of the EigenDA service manager contract
+EIGENDA_PROXY_EIGENDA_V2_SERVICE_MANAGER_ADDR=0xD4A7E1Bd8015057293f0D0A557088c286942e84b
+
+# Address of the BLS operator state retriever contract
+EIGENDA_PROXY_EIGENDA_V2_BLS_OPERATOR_STATE_RETRIEVER_ADDR=0x003497Dd77E5B73C40e8aCbB562C8bb0410320E7
 
 # === Storage Configuration ===
 

--- a/.env.exampleV1AndV2.holesky
+++ b/.env.exampleV1AndV2.holesky
@@ -56,12 +56,6 @@ EIGENDA_PROXY_EIGENDA_V2_SIGNER_PRIVATE_KEY_HEX="0000000000000000000100000000000
 # JSON RPC node endpoint for the Ethereum network (V2)
 EIGENDA_PROXY_EIGENDA_V2_ETH_RPC=https://ethereum-holesky-rpc.publicnode.com
 
-# RPC endpoint of the EigenDA disperser (V2)
-EIGENDA_PROXY_EIGENDA_V2_DISPERSER_RPC=disperser-testnet-holesky.eigenda.xyz:443
-
-# Address of the EigenDACertVerifier contract for V2
-EIGENDA_PROXY_EIGENDA_V2_CERT_VERIFIER_ADDR=0xFe52fE1940858DCb6e12153E2104aD0fDFbE1162
-
 # Disable TLS for gRPC communication with the EigenDA disperser and retrieval subnet (V2)
 EIGENDA_PROXY_EIGENDA_V2_GRPC_DISABLE_TLS=false
 
@@ -99,11 +93,9 @@ EIGENDA_PROXY_EIGENDA_V2_BLOB_PARAMS_VERSION=0
 # sent, decreasing this value is a crude sort of optimization.
 EIGENDA_PROXY_EIGENDA_V2_MAX_BLOB_LENGTH=1MiB
 
-# Address of the EigenDA service manager contract
-EIGENDA_PROXY_EIGENDA_V2_SERVICE_MANAGER_ADDR=0xD4A7E1Bd8015057293f0D0A557088c286942e84b
-
-# Address of the BLS operator state retriever contract
-EIGENDA_PROXY_EIGENDA_V2_BLS_OPERATOR_STATE_RETRIEVER_ADDR=0x003497Dd77E5B73C40e8aCbB562C8bb0410320E7
+# The EigenDA network to run on. Specifying this chooses default values for V2_DISPERSER_RPC, V2_CERT_VERIFIER_ADDR,
+# V2_SERVICE_MANAGER_ADDR, and V2_BLS_OPERATOR_STATE_RETRIEVER_ADDR.
+EIGENDA_PROXY_EIGENDA_V2_NETWORK=holesky_testnet
 
 # === Storage Configuration ===
 

--- a/.env.exampleV2.holesky
+++ b/.env.exampleV2.holesky
@@ -8,12 +8,6 @@ EIGENDA_PROXY_EIGENDA_V2_SIGNER_PRIVATE_KEY_HEX="0000000000000000000100000000000
 # JSON RPC node endpoint for the Ethereum network (V2)
 EIGENDA_PROXY_EIGENDA_V2_ETH_RPC=https://ethereum-holesky-rpc.publicnode.com
 
-# RPC endpoint of the EigenDA disperser (V2)
-EIGENDA_PROXY_EIGENDA_V2_DISPERSER_RPC=disperser-testnet-holesky.eigenda.xyz:443
-
-# Address of the EigenDACertVerifier contract for V2
-EIGENDA_PROXY_EIGENDA_V2_CERT_VERIFIER_ADDR=0xFe52fE1940858DCb6e12153E2104aD0fDFbE1162
-
 # Disable TLS for gRPC communication with the EigenDA disperser and retrieval subnet (V2)
 EIGENDA_PROXY_EIGENDA_V2_GRPC_DISABLE_TLS=false
 
@@ -51,11 +45,9 @@ EIGENDA_PROXY_EIGENDA_V2_BLOB_PARAMS_VERSION=0
 # sent, decreasing this value is a crude sort of optimization.
 EIGENDA_PROXY_EIGENDA_V2_MAX_BLOB_LENGTH=1MiB
 
-# Address of the EigenDA service manager contract (required for validator retrieval)
-EIGENDA_PROXY_EIGENDA_V2_SERVICE_MANAGER_ADDR=0xD4A7E1Bd8015057293f0D0A557088c286942e84b
-
-# Address of the BLS operator state retriever contract (required for validator retrieval)
-EIGENDA_PROXY_EIGENDA_V2_BLS_OPERATOR_STATE_RETRIEVER_ADDR=0x003497Dd77E5B73C40e8aCbB562C8bb0410320E7
+# The EigenDA network to run on. Specifying this chooses default values for V2_DISPERSER_RPC, V2_CERT_VERIFIER_ADDR,
+# V2_SERVICE_MANAGER_ADDR, and V2_BLS_OPERATOR_STATE_RETRIEVER_ADDR.
+EIGENDA_PROXY_EIGENDA_V2_NETWORK=holesky_testnet
 
 # === Storage Configuration ===
 

--- a/.env.exampleV2.holesky
+++ b/.env.exampleV2.holesky
@@ -2,7 +2,6 @@
 
 # === V2 Configuration ===
 
-
 # Hex-encoded signer private key for payments with EigenDA disperser (V2)
 EIGENDA_PROXY_EIGENDA_V2_SIGNER_PRIVATE_KEY_HEX="0000000000000000000100000000000000000000000000000000000000000000"
 
@@ -39,6 +38,9 @@ EIGENDA_PROXY_EIGENDA_V2_CONTRACT_CALL_TIMEOUT=5s
 # Timeout used when querying an individual relay for blob contents
 EIGENDA_PROXY_EIGENDA_V2_RELAY_TIMEOUT=5s
 
+# Timeout used when retrieving payload chunks directly from EigenDA validators (fallback method)
+EIGENDA_PROXY_EIGENDA_V2_VALIDATOR_TIMEOUT=2m
+
 # Blob params version used when dispersing
 EIGENDA_PROXY_EIGENDA_V2_BLOB_PARAMS_VERSION=0
 
@@ -48,6 +50,12 @@ EIGENDA_PROXY_EIGENDA_V2_BLOB_PARAMS_VERSION=0
 # you only actually need to read the amount of SRS data that corresponds to the size of the largest blob that will be
 # sent, decreasing this value is a crude sort of optimization.
 EIGENDA_PROXY_EIGENDA_V2_MAX_BLOB_LENGTH=1MiB
+
+# Address of the EigenDA service manager contract (required for validator retrieval)
+EIGENDA_PROXY_EIGENDA_V2_SERVICE_MANAGER_ADDR=0xD4A7E1Bd8015057293f0D0A557088c286942e84b
+
+# Address of the BLS operator state retriever contract (required for validator retrieval)
+EIGENDA_PROXY_EIGENDA_V2_BLS_OPERATOR_STATE_RETRIEVER_ADDR=0x003497Dd77E5B73C40e8aCbB562C8bb0410320E7
 
 # === Storage Configuration ===
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -107,7 +107,7 @@ linters-settings:
     # Default: false
     require-specific: true
 
-  usetesting:
+  tenv:
     # The option `all` will run against whole test files (`_test.go`) regardless of method/function signatures.
     # Otherwise, only methods that take `*testing.T`, `*testing.B`, and `testing.TB` as arguments are checked.
     # Default: false
@@ -166,7 +166,7 @@ linters:
     - rowserrcheck # checks whether Err of rows is checked successfully
     - sqlclosecheck # checks that sql.Rows and sql.Stmt are closed
     - stylecheck # is a replacement for golint
-    - usetesting # enforces using t.Testing APIs like t.Setenv instead of os.Setenv, testing.Short instead of os.Getenv("SHORT"), etc.
+    - tenv # detects using os.Setenv instead of t.Setenv since Go1.17
     - testableexamples # checks if examples are testable (have an expected output)
     - testpackage # makes you use a separate _test package
     - tparallel # detects inappropriate usage of t.Parallel() method in your Go test codes

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -107,7 +107,7 @@ linters-settings:
     # Default: false
     require-specific: true
 
-  tenv:
+  usetesting:
     # The option `all` will run against whole test files (`_test.go`) regardless of method/function signatures.
     # Otherwise, only methods that take `*testing.T`, `*testing.B`, and `testing.TB` as arguments are checked.
     # Default: false
@@ -166,7 +166,7 @@ linters:
     - rowserrcheck # checks whether Err of rows is checked successfully
     - sqlclosecheck # checks that sql.Rows and sql.Stmt are closed
     - stylecheck # is a replacement for golint
-    - tenv # detects using os.Setenv instead of t.Setenv since Go1.17
+    - usetesting # enforces using t.Testing APIs like t.Setenv instead of os.Setenv, testing.Short instead of os.Getenv("SHORT"), etc.
     - testableexamples # checks if examples are testable (have an expected output)
     - testpackage # makes you use a separate _test package
     - tparallel # detects inappropriate usage of t.Parallel() method in your Go test codes

--- a/common/client_config_v2.go
+++ b/common/client_config_v2.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"fmt"
+	"slices"
 
 	clients_v2 "github.com/Layr-Labs/eigenda/api/clients/v2"
 	"github.com/Layr-Labs/eigenda/api/clients/v2/payloaddispersal"
@@ -10,15 +11,23 @@ import (
 
 // ClientConfigV2 contains all non-sensitive configuration to construct V2 clients
 type ClientConfigV2 struct {
-	DisperserClientCfg       clients_v2.DisperserClientConfig
-	PayloadDisperserCfg      payloaddispersal.PayloadDisperserConfig
-	RelayPayloadRetrieverCfg payloadretrieval.RelayPayloadRetrieverConfig
+	DisperserClientCfg           clients_v2.DisperserClientConfig
+	PayloadDisperserCfg          payloaddispersal.PayloadDisperserConfig
+	RelayPayloadRetrieverCfg     payloadretrieval.RelayPayloadRetrieverConfig
+	ValidatorPayloadRetrieverCfg payloadretrieval.ValidatorPayloadRetrieverConfig
 
 	// The following fields are not needed directly by any underlying components. Rather, these are configuration
 	// values required by the proxy itself.
 	PutRetries                 uint
 	MaxBlobSizeBytes           uint64
 	EigenDACertVerifierAddress string
+
+	// Fields required for validator payload retrieval
+	BLSOperatorStateRetrieverAddr string
+	EigenDAServiceManagerAddr     string
+
+	// RetrieversToEnable specifies which retrievers should be enabled
+	RetrieversToEnable []RetrieverType
 }
 
 // Check checks config invariants, and returns an error if there is a problem with the config struct
@@ -39,5 +48,30 @@ func (cfg *ClientConfigV2) Check() error {
 		return fmt.Errorf("max blob size is required for using EigenDA V2 backend")
 	}
 
+	// Check if at least one retriever is enabled
+	if len(cfg.RetrieversToEnable) == 0 {
+		return fmt.Errorf("at least one retriever type must be enabled for using EigenDA V2 backend")
+	}
+
+	if slices.Contains(cfg.RetrieversToEnable, ValidatorRetrieverType) {
+		if cfg.BLSOperatorStateRetrieverAddr == "" {
+			return fmt.Errorf(
+				"BLS operator state retriever address is required for validator retrieval in EigenDA V2 backend")
+		}
+
+		if cfg.EigenDAServiceManagerAddr == "" {
+			return fmt.Errorf(
+				"EigenDA service manager address is required for validator retrieval in EigenDA V2 backend")
+		}
+	}
+
 	return nil
 }
+
+// RetrieverType defines the type of payload retriever
+type RetrieverType string
+
+const (
+	RelayRetrieverType     RetrieverType = "relayRetriever"
+	ValidatorRetrieverType RetrieverType = "validatorRetriever"
+)

--- a/common/eigenda_network.go
+++ b/common/eigenda_network.go
@@ -1,0 +1,73 @@
+package common
+
+import "fmt"
+
+type EigenDANetwork string
+
+const (
+	HoleskyTestnetEigenDANetwork EigenDANetwork = "holesky_testnet"
+	HoleskyPreprodEigenDANetwork EigenDANetwork = "holesky_preprod"
+)
+
+// GetServiceManagerAddress returns, as a string, the address of the EigenDAServiceManager contract for the network.
+func (n EigenDANetwork) GetServiceManagerAddress() (string, error) {
+	switch n {
+	case HoleskyTestnetEigenDANetwork:
+		return "0xD4A7E1Bd8015057293f0D0A557088c286942e84b", nil
+	case HoleskyPreprodEigenDANetwork:
+		return "0x54A03db2784E3D0aCC08344D05385d0b62d4F432", nil
+	default:
+		return "", fmt.Errorf("unknown network type: %s", n)
+	}
+}
+
+// GetDisperserAddress gets a string representing the address of the disperser for the network.
+// The format of the returned address is "<hostname>:<port>"
+func (n EigenDANetwork) GetDisperserAddress() (string, error) {
+	switch n {
+	case HoleskyTestnetEigenDANetwork:
+		return "disperser-testnet-holesky.eigenda.xyz:443", nil
+	case HoleskyPreprodEigenDANetwork:
+		return "disperser-preprod-holesky.eigenda.xyz:443", nil
+	default:
+		return "", fmt.Errorf("unknown network type: %s", n)
+	}
+}
+
+// GetCertVerifierAddress returns, as a string, the address of the EigenDACertVerifier contract for the network.
+func (n EigenDANetwork) GetCertVerifierAddress() (string, error) {
+	switch n {
+	case HoleskyTestnetEigenDANetwork:
+		return "0xFe52fE1940858DCb6e12153E2104aD0fDFbE1162", nil
+	case HoleskyPreprodEigenDANetwork:
+		return "0xd973fA62E22BC2779F8489258F040C0344B03C21", nil
+	default:
+		return "", fmt.Errorf("unknown network type: %s", n)
+	}
+}
+
+// GetBLSOperatorStateRetrieverAddress returns, as a string, the address of the OperatorStateRetriever contract for the
+// network
+func (n EigenDANetwork) GetBLSOperatorStateRetrieverAddress() (string, error) {
+	switch n {
+	case HoleskyTestnetEigenDANetwork, HoleskyPreprodEigenDANetwork:
+		return "0x003497Dd77E5B73C40e8aCbB562C8bb0410320E7", nil
+	default:
+		return "", fmt.Errorf("unknown network: %s", n)
+	}
+}
+
+func (n EigenDANetwork) String() string {
+	return string(n)
+}
+
+func EigenDANetworkFromString(inputString string) (EigenDANetwork, error) {
+	network := EigenDANetwork(inputString)
+
+	switch network {
+	case HoleskyTestnetEigenDANetwork, HoleskyPreprodEigenDANetwork:
+		return network, nil
+	default:
+		return "", fmt.Errorf("unknown network type: %s", inputString)
+	}
+}

--- a/config/proxy_config.go
+++ b/config/proxy_config.go
@@ -32,21 +32,28 @@ type ProxyConfig struct {
 
 // ReadProxyConfig ... parses the Config from the provided flags or environment variables.
 func ReadProxyConfig(ctx *cli.Context) (ProxyConfig, error) {
-	clientConfigV1, err := eigendaflags.ReadClientConfigV1(ctx)
-	if err != nil {
-		return ProxyConfig{}, fmt.Errorf("read client config v1: %w", err)
-	}
-
-	verifierConfigV1 := verify.ReadConfig(ctx, clientConfigV1)
-
-	clientConfigV2, err := eigendaflags_v2.ReadClientConfigV2(ctx)
-	if err != nil {
-		return ProxyConfig{}, fmt.Errorf("read client config v2: %w", err)
-	}
-
 	storageConfig, err := store.ReadConfig(ctx)
 	if err != nil {
 		return ProxyConfig{}, fmt.Errorf("read storage config: %w", err)
+	}
+
+	var clientConfigV1 common.ClientConfigV1
+	var verifierConfigV1 verify.Config
+	if slices.Contains(storageConfig.BackendsToEnable, common.V1EigenDABackend) {
+		clientConfigV1, err := eigendaflags.ReadClientConfigV1(ctx)
+		if err != nil {
+			return ProxyConfig{}, fmt.Errorf("read client config v1: %w", err)
+		}
+
+		verifierConfigV1 = verify.ReadConfig(ctx, clientConfigV1)
+	}
+
+	var clientConfigV2 common.ClientConfigV2
+	if slices.Contains(storageConfig.BackendsToEnable, common.V2EigenDABackend) {
+		clientConfigV2, err = eigendaflags_v2.ReadClientConfigV2(ctx)
+		if err != nil {
+			return ProxyConfig{}, fmt.Errorf("read client config v2: %w", err)
+		}
 	}
 
 	var maxBlobSizeBytes uint64

--- a/config/proxy_config.go
+++ b/config/proxy_config.go
@@ -40,7 +40,7 @@ func ReadProxyConfig(ctx *cli.Context) (ProxyConfig, error) {
 	var clientConfigV1 common.ClientConfigV1
 	var verifierConfigV1 verify.Config
 	if slices.Contains(storageConfig.BackendsToEnable, common.V1EigenDABackend) {
-		clientConfigV1, err := eigendaflags.ReadClientConfigV1(ctx)
+		clientConfigV1, err = eigendaflags.ReadClientConfigV1(ctx)
 		if err != nil {
 			return ProxyConfig{}, fmt.Errorf("read client config v1: %w", err)
 		}

--- a/config/proxy_config_test.go
+++ b/config/proxy_config_test.go
@@ -59,8 +59,11 @@ func validCfg() ProxyConfig {
 				Port:              "9999",
 				UseSecureGrpcFlag: true,
 			},
-			EigenDACertVerifierAddress: "0x0000000000032443134",
-			MaxBlobSizeBytes:           maxBlobLengthBytes,
+			EigenDACertVerifierAddress:    "0x0000000000032443134",
+			MaxBlobSizeBytes:              maxBlobLengthBytes,
+			BLSOperatorStateRetrieverAddr: "0x000000000004324311",
+			EigenDAServiceManagerAddr:     "0x000000000005324322",
+			RetrieversToEnable:            []common.RetrieverType{common.RelayRetrieverType, common.ValidatorRetrieverType},
 		},
 		StorageConfig: store.Config{
 			BackendsToEnable: []common.EigenDABackend{common.V1EigenDABackend, common.V2EigenDABackend},

--- a/config/v2/eigendaflags/cli.go
+++ b/config/v2/eigendaflags/cli.go
@@ -183,10 +183,10 @@ func CLIFlags(envPrefix, category string) []cli.Flag {
 						network flag may be omitted. If some or all of these fields are configured, and the network
 						is also configured, then the explicitly defined field values will take precedence. Permitted
 						EigenDANetwork values include %s, and %s.`,
-				withEnvPrefix(envPrefix, DisperserFlagName),
-				withEnvPrefix(envPrefix, CertVerifierAddrFlagName),
-				withEnvPrefix(envPrefix, ServiceManagerAddrFlagName),
-				withEnvPrefix(envPrefix, BLSOperatorStateRetrieverFlagName),
+				DisperserFlagName,
+				CertVerifierAddrFlagName,
+				ServiceManagerAddrFlagName,
+				BLSOperatorStateRetrieverFlagName,
 				common.HoleskyTestnetEigenDANetwork,
 				common.HoleskyPreprodEigenDANetwork),
 			EnvVars:  []string{withEnvPrefix(envPrefix, "NETWORK")},

--- a/config/v2/eigendaflags/cli.go
+++ b/config/v2/eigendaflags/cli.go
@@ -173,6 +173,11 @@ func ReadClientConfigV2(ctx *cli.Context) (common.ClientConfigV2, error) {
 		PutRetries:                 ctx.Uint(PutRetriesFlagName),
 		MaxBlobSizeBytes:           maxBlobLengthBytes,
 		EigenDACertVerifierAddress: ctx.String(CertVerifierAddrFlagName),
+		// we don't expose this configuration to users, as all production use cases should have
+		// both retrieval methods enabled. This could be exposed in the future, if necessary.
+		// Note the order of these retrievers, which is significant: the relay retriever will be
+		// tried first, and the validator retriever will only be tried if the relay retriever fails
+		RetrieversToEnable: []common.RetrieverType{common.RelayRetrieverType, common.ValidatorRetrieverType},
 	}, nil
 }
 
@@ -205,7 +210,7 @@ func readPayloadDisperserCfg(ctx *cli.Context) payloaddispersal.PayloadDisperser
 	return payloaddispersal.PayloadDisperserConfig{
 		PayloadClientConfig:    payCfg,
 		DisperseBlobTimeout:    ctx.Duration(DisperseBlobTimeoutFlagName),
-		BlobCertifiedTimeout:   ctx.Duration(BlobCertifiedTimeoutFlagName),
+		BlobCompleteTimeout:    ctx.Duration(BlobCertifiedTimeoutFlagName),
 		BlobStatusPollInterval: ctx.Duration(BlobStatusPollIntervalFlagName),
 		ContractCallTimeout:    ctx.Duration(ContractCallTimeoutFlagName),
 	}

--- a/docs/help_out.txt
+++ b/docs/help_out.txt
@@ -50,10 +50,8 @@ GLOBAL OPTIONS:
 
    --eigenda.v2.blob-certified-timeout value             Maximum amount of time to wait for blob certification against the on-chain EigenDACertVerifier. (default: 30s) [$EIGENDA_PROXY_EIGENDA_V2_CERTIFY_BLOB_TIMEOUT]
    --eigenda.v2.blob-status-poll-interval value          Duration to query for blob status updates during dispersal. (default: 1s) [$EIGENDA_PROXY_EIGENDA_V2_BLOB_STATUS_POLL_INTERVAL]
-   --eigenda.v2.blob-version value                       Blob params version used when dispersing. 
-                                                                    This refers to a global version maintained by EigenDA governance 
-                                                                    and is injected in the BlobHeader before dispersing.
-                                                                    Currently only supports (0). (default: 0) [$EIGENDA_PROXY_EIGENDA_V2_BLOB_PARAMS_VERSION]
+   --eigenda.v2.blob-version value                       Blob params version used when dispersing. This refers to a global version maintained by EigenDA
+                                                                   governance and is injected in the BlobHeader before dispersing. Currently only supports (0). (default: 0) [$EIGENDA_PROXY_EIGENDA_V2_BLOB_PARAMS_VERSION]
    --eigenda.v2.bls-operator-state-retriever-addr value  Address of the BLS operator state retriever contract. [$EIGENDA_PROXY_EIGENDA_V2_BLS_OPERATOR_STATE_RETRIEVER_ADDR]
    --eigenda.v2.cert-verifier-addr value                 Address of the EigenDACertVerifier contract. Required for performing eth_calls to verify EigenDA certificates. [$EIGENDA_PROXY_EIGENDA_V2_CERT_VERIFIER_ADDR]
    --eigenda.v2.contract-call-timeout value              Timeout used when performing smart contract call operation (i.e, eth_call). (default: 10s) [$EIGENDA_PROXY_EIGENDA_V2_CONTRACT_CALL_TIMEOUT]
@@ -65,6 +63,11 @@ GLOBAL OPTIONS:
    --eigenda.v2.max-blob-length value                    Maximum blob length to be written or read from EigenDA. Determines the number of SRS points
                                                                    loaded into memory for KZG commitments. Example units: '30MiB', '4Kb', '30MB'. Maximum size
                                                                    slightly exceeds 1GB. (default: "16MiB") [$EIGENDA_PROXY_EIGENDA_V2_MAX_BLOB_LENGTH]
+   --eigenda.v2.network value                            The EigenDA network that is being used. This is an optional flag, to configure
+                                                                   default values for eigenda.v2.disperser-rpc, eigenda.v2.cert-verifier-addr, eigenda.v2.service-manager-addr, and eigenda.v2.bls-operator-state-retriever-addr. If all of these fields are explicitly configured, the
+                                                                   network flag may be omitted. If some or all of these fields are configured, and the network
+                                                                   is also configured, then the explicitly defined field values will take precedence. Permitted
+                                                                   EigenDANetwork values include holesky_testnet, and holesky_preprod. [$EIGENDA_PROXY_EIGENDA_V2_NETWORK]
    --eigenda.v2.put-retries value                        Total number of times to try blob dispersals before serving an error response.>0 = try dispersal that many times. <0 = retry indefinitely. 0 is not permitted (causes startup error). (default: 3) [$EIGENDA_PROXY_EIGENDA_V2_PUT_RETRIES]
    --eigenda.v2.relay-timeout value                      Timeout used when querying an individual relay for blob contents. (default: 10s) [$EIGENDA_PROXY_EIGENDA_V2_RELAY_TIMEOUT]
    --eigenda.v2.service-manager-addr value               Address of the EigenDA service manager contract. [$EIGENDA_PROXY_EIGENDA_V2_SERVICE_MANAGER_ADDR]

--- a/docs/help_out.txt
+++ b/docs/help_out.txt
@@ -48,25 +48,28 @@ GLOBAL OPTIONS:
 
    EigenDA V2 Client
 
-   --eigenda.v2.blob-certified-timeout value     Maximum amount of time to wait for blob certification against the on-chain EigenDACertVerifier. (default: 30s) [$EIGENDA_PROXY_EIGENDA_V2_CERTIFY_BLOB_TIMEOUT]
-   --eigenda.v2.blob-status-poll-interval value  Duration to query for blob status updates during dispersal. (default: 1s) [$EIGENDA_PROXY_EIGENDA_V2_BLOB_STATUS_POLL_INTERVAL]
-   --eigenda.v2.blob-version value               Blob params version used when dispersing. 
-                                                            This refers to a global version maintained by EigenDA governance 
-                                                            and is injected in the BlobHeader before dispersing.
-                                                            Currently only supports (0). (default: 0) [$EIGENDA_PROXY_EIGENDA_V2_BLOB_PARAMS_VERSION]
-   --eigenda.v2.cert-verifier-addr value         Address of the EigenDACertVerifier contract. Required for performing eth_calls to verify EigenDA certificates. [$EIGENDA_PROXY_EIGENDA_V2_CERT_VERIFIER_ADDR]
-   --eigenda.v2.contract-call-timeout value      Timeout used when performing smart contract call operation (i.e, eth_call). (default: 10s) [$EIGENDA_PROXY_EIGENDA_V2_CONTRACT_CALL_TIMEOUT]
-   --eigenda.v2.disable-point-evaluation         Disables IFFT transformation done during payload encoding. Using this mode results in blobs that can't be proven. (default: false) [$EIGENDA_PROXY_EIGENDA_V2_DISABLE_POINT_EVALUATION]
-   --eigenda.v2.disable-tls                      Disable TLS for gRPC communication with the EigenDA disperser and retrieval subnet. (default: false) [$EIGENDA_PROXY_EIGENDA_V2_GRPC_DISABLE_TLS]
-   --eigenda.v2.disperse-blob-timeout value      Maximum amount of time to wait for a blob to disperse against v2 protocol. (default: 2m0s) [$EIGENDA_PROXY_EIGENDA_V2_DISPERSE_BLOB_TIMEOUT]
-   --eigenda.v2.disperser-rpc value              RPC endpoint of the EigenDA disperser. [$EIGENDA_PROXY_EIGENDA_V2_DISPERSER_RPC]
-   --eigenda.v2.eth-rpc value                    URL of the Ethereum RPC endpoint. [$EIGENDA_PROXY_EIGENDA_V2_ETH_RPC]
-   --eigenda.v2.max-blob-length value            Maximum blob length to be written or read from EigenDA. Determines the number of SRS points
-                                                           loaded into memory for KZG commitments. Example units: '30MiB', '4Kb', '30MB'. Maximum size
-                                                           slightly exceeds 1GB. (default: "16MiB") [$EIGENDA_PROXY_EIGENDA_V2_MAX_BLOB_LENGTH]
-   --eigenda.v2.put-retries value                Number of times to retry blob dispersals before serving an error response. (default: 3) [$EIGENDA_PROXY_EIGENDA_V2_PUT_RETRIES]
-   --eigenda.v2.relay-timeout value              Timeout used when querying an individual relay for blob contents. (default: 10s) [$EIGENDA_PROXY_EIGENDA_V2_RELAY_TIMEOUT]
-   --eigenda.v2.signer-payment-key-hex value     Hex-encoded signer private key. Used for authorizing payments with EigenDA disperser. Should not be associated with an Ethereum address holding any funds. [$EIGENDA_PROXY_EIGENDA_V2_SIGNER_PRIVATE_KEY_HEX]
+   --eigenda.v2.blob-certified-timeout value             Maximum amount of time to wait for blob certification against the on-chain EigenDACertVerifier. (default: 30s) [$EIGENDA_PROXY_EIGENDA_V2_CERTIFY_BLOB_TIMEOUT]
+   --eigenda.v2.blob-status-poll-interval value          Duration to query for blob status updates during dispersal. (default: 1s) [$EIGENDA_PROXY_EIGENDA_V2_BLOB_STATUS_POLL_INTERVAL]
+   --eigenda.v2.blob-version value                       Blob params version used when dispersing. 
+                                                                    This refers to a global version maintained by EigenDA governance 
+                                                                    and is injected in the BlobHeader before dispersing.
+                                                                    Currently only supports (0). (default: 0) [$EIGENDA_PROXY_EIGENDA_V2_BLOB_PARAMS_VERSION]
+   --eigenda.v2.bls-operator-state-retriever-addr value  Address of the BLS operator state retriever contract. [$EIGENDA_PROXY_EIGENDA_V2_BLS_OPERATOR_STATE_RETRIEVER_ADDR]
+   --eigenda.v2.cert-verifier-addr value                 Address of the EigenDACertVerifier contract. Required for performing eth_calls to verify EigenDA certificates. [$EIGENDA_PROXY_EIGENDA_V2_CERT_VERIFIER_ADDR]
+   --eigenda.v2.contract-call-timeout value              Timeout used when performing smart contract call operation (i.e, eth_call). (default: 10s) [$EIGENDA_PROXY_EIGENDA_V2_CONTRACT_CALL_TIMEOUT]
+   --eigenda.v2.disable-point-evaluation                 Disables IFFT transformation done during payload encoding. Using this mode results in blobs that can't be proven. (default: false) [$EIGENDA_PROXY_EIGENDA_V2_DISABLE_POINT_EVALUATION]
+   --eigenda.v2.disable-tls                              Disable TLS for gRPC communication with the EigenDA disperser and retrieval subnet. (default: false) [$EIGENDA_PROXY_EIGENDA_V2_GRPC_DISABLE_TLS]
+   --eigenda.v2.disperse-blob-timeout value              Maximum amount of time to wait for a blob to disperse against v2 protocol. (default: 2m0s) [$EIGENDA_PROXY_EIGENDA_V2_DISPERSE_BLOB_TIMEOUT]
+   --eigenda.v2.disperser-rpc value                      RPC endpoint of the EigenDA disperser. [$EIGENDA_PROXY_EIGENDA_V2_DISPERSER_RPC]
+   --eigenda.v2.eth-rpc value                            URL of the Ethereum RPC endpoint. [$EIGENDA_PROXY_EIGENDA_V2_ETH_RPC]
+   --eigenda.v2.max-blob-length value                    Maximum blob length to be written or read from EigenDA. Determines the number of SRS points
+                                                                   loaded into memory for KZG commitments. Example units: '30MiB', '4Kb', '30MB'. Maximum size
+                                                                   slightly exceeds 1GB. (default: "16MiB") [$EIGENDA_PROXY_EIGENDA_V2_MAX_BLOB_LENGTH]
+   --eigenda.v2.put-retries value                        Number of times to retry blob dispersals before serving an error response. (default: 3) [$EIGENDA_PROXY_EIGENDA_V2_PUT_RETRIES]
+   --eigenda.v2.relay-timeout value                      Timeout used when querying an individual relay for blob contents. (default: 10s) [$EIGENDA_PROXY_EIGENDA_V2_RELAY_TIMEOUT]
+   --eigenda.v2.service-manager-addr value               Address of the EigenDA service manager contract. [$EIGENDA_PROXY_EIGENDA_V2_SERVICE_MANAGER_ADDR]
+   --eigenda.v2.signer-payment-key-hex value             Hex-encoded signer private key. Used for authorizing payments with EigenDA disperser. Should not be associated with an Ethereum address holding any funds. [$EIGENDA_PROXY_EIGENDA_V2_SIGNER_PRIVATE_KEY_HEX]
+   --eigenda.v2.validator-timeout value                  Timeout used when retrieving chunks directly from EigenDA validators. This is a secondary retrieval method, in case retrieval from the relay network fails. (default: 2m0s) [$EIGENDA_PROXY_EIGENDA_V2_VALIDATOR_TIMEOUT]
 
    KZG
 

--- a/e2e/server_test.go
+++ b/e2e/server_test.go
@@ -510,3 +510,21 @@ func testMaxBlobSize(t *testing.T, dispersalBackend common.EigenDABackend) {
 	requireStandardClientSetGet(t, ts, testutils.RandBytes(int(maxPayloadSize)))
 	requireDispersalRetrievalEigenDA(t, ts.Metrics.HTTPServerRequestsTotal, commitments.Standard)
 }
+
+// TestV2ValidatorRetrieverOnly tests that retrieval works when only the validator retriever is enabled
+func TestV2ValidatorRetrieverOnly(t *testing.T) {
+	if testutils.GetBackend() == testutils.MemstoreBackend {
+		t.Skip("Don't run for memstore backend, since memstore tests don't actually hit the retrievers")
+	}
+
+	testCfg := testutils.NewTestConfig(testutils.GetBackend(), common.V2EigenDABackend, nil)
+	// Modify the test config to only use the validator retriever
+	testCfg.Retrievers = []common.RetrieverType{common.ValidatorRetrieverType}
+
+	tsConfig := testutils.BuildTestSuiteConfig(testCfg)
+	ts, kill := testutils.CreateTestSuite(tsConfig)
+	defer kill()
+
+	requireStandardClientSetGet(t, ts, testutils.RandBytes(1000))
+	requireDispersalRetrievalEigenDA(t, ts.Metrics.HTTPServerRequestsTotal, commitments.Standard)
+}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.22.7
 
 require (
-	github.com/Layr-Labs/eigenda v0.9.0
+	github.com/Layr-Labs/eigenda v0.9.1-0.20250411174037-b6b545d7cbf6
 	github.com/Layr-Labs/eigenda-proxy/clients v0.0.0-00010101000000-000000000000
 	github.com/Layr-Labs/eigensdk-go v0.2.0-beta.1.0.20250118004418-2a25f31b3b28
 	github.com/avast/retry-go/v4 v4.6.0

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/DataDog/zstd v1.5.6-0.20230824185856-869dae002e5e h1:ZIWapoIRN1VqT8GR
 github.com/DataDog/zstd v1.5.6-0.20230824185856-869dae002e5e/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/Layr-Labs/cerberus-api v0.0.2-0.20250117193600-e69c5e8b08fd h1:prMzW4BY6KZtWEanf5EIsyHzIZKCNV2mVIXrE6glRRM=
 github.com/Layr-Labs/cerberus-api v0.0.2-0.20250117193600-e69c5e8b08fd/go.mod h1:Lm4fhzy0S3P7GjerzuseGaBFVczsIKmEhIjcT52Hluo=
-github.com/Layr-Labs/eigenda v0.9.0 h1:Dmaqt4YR021Nyrvz+fNemTdezHObu3qvZopqq6NLjWU=
-github.com/Layr-Labs/eigenda v0.9.0/go.mod h1:MO3EyBXCmhzttrmmgqmIkzDg4gtqWjU+0fxSN0Q1EmM=
+github.com/Layr-Labs/eigenda v0.9.1-0.20250411174037-b6b545d7cbf6 h1:ZWwH1IEFNdVER84yfVM72WROwsUVoSpHA5jFBFaQa6o=
+github.com/Layr-Labs/eigenda v0.9.1-0.20250411174037-b6b545d7cbf6/go.mod h1:MO3EyBXCmhzttrmmgqmIkzDg4gtqWjU+0fxSN0Q1EmM=
 github.com/Layr-Labs/eigensdk-go v0.2.0-beta.1.0.20250118004418-2a25f31b3b28 h1:Wig5FBBizIB5Z/ZcXJlm7KdOLnrXc6E3DjO63uWRzQM=
 github.com/Layr-Labs/eigensdk-go v0.2.0-beta.1.0.20250118004418-2a25f31b3b28/go.mod h1:YNzORpoebdDNv0sJLm/H9LTx72M85zA54eBSXI5DULw=
 github.com/Layr-Labs/eigensdk-go/signer v0.0.0-20250118004418-2a25f31b3b28 h1:rhIC2XpFpCcRkv4QYczIUe/fXvE4T+0B1mF9f6NJCuo=

--- a/store/generated_key/memstore/memstore_test.go
+++ b/store/generated_key/memstore/memstore_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Layr-Labs/eigenda-proxy/store/generated_key/memstore/memconfig"
 	"github.com/Layr-Labs/eigenda-proxy/verify"
 	"github.com/Layr-Labs/eigenda/encoding/kzg"
+	kzgverifier "github.com/Layr-Labs/eigenda/encoding/kzg/verifier"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/stretchr/testify/require"
 )
@@ -46,9 +47,13 @@ func TestGetSet(t *testing.T) {
 		SRSOrder:        3000,
 		SRSNumberToLoad: 3000,
 		NumWorker:       uint64(runtime.GOMAXPROCS(0)),
+		LoadG2Points:    false,
 	}
 
-	verifier, err := verify.NewVerifier(verifierConfig, kzgConfig, nil)
+	kzgVerifier, err := kzgverifier.NewVerifier(&kzgConfig, nil)
+	require.NoError(t, err)
+
+	verifier, err := verify.NewVerifier(verifierConfig, kzgVerifier, nil)
 	require.NoError(t, err)
 
 	ms, err := New(

--- a/store/storage_manager_builder.go
+++ b/store/storage_manager_builder.go
@@ -26,9 +26,11 @@ import (
 	common_eigenda "github.com/Layr-Labs/eigenda/common"
 	"github.com/Layr-Labs/eigenda/common/geth"
 	auth "github.com/Layr-Labs/eigenda/core/auth/v2"
+	"github.com/Layr-Labs/eigenda/core/eth"
 	core_v2 "github.com/Layr-Labs/eigenda/core/v2"
 	"github.com/Layr-Labs/eigenda/encoding/kzg"
 	"github.com/Layr-Labs/eigenda/encoding/kzg/prover"
+	kzgverifier "github.com/Layr-Labs/eigenda/encoding/kzg/verifier"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/consensys/gnark-crypto/ecc/bn254"
 	geth_common "github.com/ethereum/go-ethereum/common"
@@ -118,9 +120,27 @@ func (smb *StorageManagerBuilder) Build(ctx context.Context) (*Manager, error) {
 		return nil, fmt.Errorf("dispersal backend is set to V1, but V1 backend is not enabled")
 	}
 
+	var kzgVerifier *kzgverifier.Verifier
+	// there are two cases in which we need to construct the kzgVerifier:
+	// 1. V1
+	// 2. V2, when validator retrieval is enabled
+	if v1Enabled || v2Enabled && slices.Contains(smb.v2ClientCfg.RetrieversToEnable, common.ValidatorRetrieverType) {
+		// The verifier doesn't support loading trailing g2 points from a separate file. If LoadG2Points is true, and
+		// the user is using a slimmed down g2 SRS file, the verifier will encounter an error while trying to load g2
+		// points. Since the verifier doesn't actually need g2 points, it's safe to force LoadG2Points to false, to
+		// sidestep the issue entirely.
+		kzgConfig := smb.kzgConfig
+		kzgConfig.LoadG2Points = false
+
+		kzgVerifier, err = kzgverifier.NewVerifier(&kzgConfig, nil)
+		if err != nil {
+			return nil, fmt.Errorf("new kzg verifier: %w", err)
+		}
+	}
+
 	if v1Enabled {
 		smb.log.Info("Building EigenDA v1 storage backend")
-		eigenDAV1Store, err = smb.buildEigenDAV1Backend(ctx)
+		eigenDAV1Store, err = smb.buildEigenDAV1Backend(ctx, kzgVerifier)
 		if err != nil {
 			return nil, fmt.Errorf("build v1 backend: %w", err)
 		}
@@ -128,7 +148,7 @@ func (smb *StorageManagerBuilder) Build(ctx context.Context) (*Manager, error) {
 
 	if v2Enabled {
 		smb.log.Info("Building EigenDA v2 storage backend")
-		eigenDAV2Store, err = smb.buildEigenDAV2Backend(ctx)
+		eigenDAV2Store, err = smb.buildEigenDAV2Backend(ctx, kzgVerifier)
 		if err != nil {
 			return nil, fmt.Errorf("build v2 backend: %w", err)
 		}
@@ -192,7 +212,10 @@ func (smb *StorageManagerBuilder) buildSecondaries(
 }
 
 // buildEigenDAV2Backend ... Builds EigenDA V2 storage backend
-func (smb *StorageManagerBuilder) buildEigenDAV2Backend(ctx context.Context) (common.GeneratedKeyStore, error) {
+func (smb *StorageManagerBuilder) buildEigenDAV2Backend(
+	ctx context.Context,
+	kzgVerifier *kzgverifier.Verifier,
+) (common.GeneratedKeyStore, error) {
 	// This is a bit of a hack. The kzg config is used by both v1 AND v2, but the `LoadG2Points` field has special
 	// requirements. For v1, it must always be false. For v2, it must always be true. Ideally, we would modify
 	// the underlying core library to be more flexible, but that is a larger change for another time. As a stopgap, we
@@ -223,13 +246,35 @@ func (smb *StorageManagerBuilder) buildEigenDAV2Backend(ctx context.Context) (co
 		return nil, fmt.Errorf("new cert verifier: %w", err)
 	}
 
-	relayRegistryAddress, err := certVerifier.GetRelayRegistryAddress(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("get relay registry address: %w", err)
+	var retrievers []clients_v2.PayloadRetriever
+
+	// Initialize relay retriever if enabled
+	if slices.Contains(smb.v2ClientCfg.RetrieversToEnable, common.RelayRetrieverType) {
+		smb.log.Info("Initializing relay payload retriever")
+		relayRegistryAddress, err := certVerifier.GetRelayRegistryAddress(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("get relay registry address: %w", err)
+		}
+		relayPayloadRetriever, err := smb.buildRelayPayloadRetriever(ethClient, kzgProver.Srs.G1, *relayRegistryAddress)
+		if err != nil {
+			return nil, fmt.Errorf("build relay payload retriever: %w", err)
+		}
+		retrievers = append(retrievers, relayPayloadRetriever)
 	}
-	relayPayloadRetriever, err := smb.buildRelayPayloadRetriever(ethClient, kzgProver.Srs.G1, *relayRegistryAddress)
-	if err != nil {
-		return nil, fmt.Errorf("build relay payload retriever: %w", err)
+
+	// Initialize validator retriever if enabled
+	if slices.Contains(smb.v2ClientCfg.RetrieversToEnable, common.ValidatorRetrieverType) {
+		smb.log.Info("Initializing validator payload retriever")
+		validatorPayloadRetriever, err := smb.buildValidatorPayloadRetriever(ethClient, kzgVerifier, kzgProver.Srs.G1)
+		if err != nil {
+			return nil, fmt.Errorf("build validator payload retriever: %w", err)
+		}
+		retrievers = append(retrievers, validatorPayloadRetriever)
+	}
+
+	// Ensure at least one retriever is configured
+	if len(retrievers) == 0 {
+		return nil, fmt.Errorf("no payload retrievers enabled, please enable at least one retriever type")
 	}
 
 	payloadDisperser, err := smb.buildPayloadDisperser(ctx, ethClient, kzgProver, certVerifier)
@@ -241,13 +286,16 @@ func (smb *StorageManagerBuilder) buildEigenDAV2Backend(ctx context.Context) (co
 		smb.log,
 		smb.v2ClientCfg.PutRetries,
 		payloadDisperser,
-		relayPayloadRetriever,
+		retrievers,
 		certVerifier)
 }
 
 // buildEigenDAV1Backend ... Builds EigenDA V1 storage backend
-func (smb *StorageManagerBuilder) buildEigenDAV1Backend(ctx context.Context) (common.GeneratedKeyStore, error) {
-	verifier, err := verify.NewVerifier(&smb.v1VerifierCfg, smb.kzgConfig, smb.log)
+func (smb *StorageManagerBuilder) buildEigenDAV1Backend(
+	ctx context.Context,
+	kzgVerifier *kzgverifier.Verifier,
+) (common.GeneratedKeyStore, error) {
+	verifier, err := verify.NewVerifier(&smb.v1VerifierCfg, kzgVerifier, smb.log)
 	if err != nil {
 		return nil, fmt.Errorf("new verifier: %w", err)
 	}
@@ -344,6 +392,56 @@ func (smb *StorageManagerBuilder) buildRelayClient(
 	return relayClient, nil
 }
 
+// buildValidatorPayloadRetriever constructs a ValidatorPayloadRetriever for retrieving
+// payloads directly from EigenDA validators
+func (smb *StorageManagerBuilder) buildValidatorPayloadRetriever(
+	ethClient common_eigenda.EthClient,
+	kzgVerifier *kzgverifier.Verifier,
+	g1Srs []bn254.G1Affine,
+) (*payloadretrieval.ValidatorPayloadRetriever, error) {
+	ethReader, err := smb.buildEthReader(ethClient)
+	if err != nil {
+		return nil, fmt.Errorf("build eth reader: %w", err)
+	}
+
+	chainState := eth.NewChainState(ethReader, ethClient)
+
+	retrievalClient := clients_v2.NewRetrievalClient(
+		smb.log,
+		ethReader,
+		chainState,
+		kzgVerifier,
+		20, // Default connection count
+	)
+
+	// Create validator payload retriever
+	validatorRetriever, err := payloadretrieval.NewValidatorPayloadRetriever(
+		smb.log,
+		smb.v2ClientCfg.ValidatorPayloadRetrieverCfg,
+		retrievalClient,
+		g1Srs,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("new validator payload retriever: %w", err)
+	}
+
+	return validatorRetriever, nil
+}
+
+func (smb *StorageManagerBuilder) buildEthReader(ethClient common_eigenda.EthClient) (*eth.Reader, error) {
+	ethReader, err := eth.NewReader(
+		smb.log,
+		ethClient,
+		smb.v2ClientCfg.BLSOperatorStateRetrieverAddr,
+		smb.v2ClientCfg.EigenDAServiceManagerAddr,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("new reader: %w", err)
+	}
+
+	return ethReader, nil
+}
+
 func (smb *StorageManagerBuilder) buildPayloadDisperser(
 	ctx context.Context,
 	ethClient common_eigenda.EthClient,
@@ -364,7 +462,8 @@ func (smb *StorageManagerBuilder) buildPayloadDisperser(
 		smb.log,
 		smb.v2ClientCfg.PayloadDisperserCfg,
 		disperserClient,
-		certVerifier)
+		certVerifier,
+		nil)
 	if err != nil {
 		return nil, fmt.Errorf("new payload disperser: %w", err)
 	}

--- a/testutils/setup.go
+++ b/testutils/setup.go
@@ -41,13 +41,15 @@ const (
 	host             = "127.0.0.1"
 	disperserPort    = "443"
 
-	disperserPreprodHostname   = "disperser-preprod-holesky.eigenda.xyz"
-	preprodCertVerifierAddress = "0xd973fA62E22BC2779F8489258F040C0344B03C21"
-	preprodSvcManagerAddress   = "0x54A03db2784E3D0aCC08344D05385d0b62d4F432"
+	disperserPreprodHostname                = "disperser-preprod-holesky.eigenda.xyz"
+	preprodCertVerifierAddress              = "0xd973fA62E22BC2779F8489258F040C0344B03C21"
+	preprodSvcManagerAddress                = "0x54A03db2784E3D0aCC08344D05385d0b62d4F432"
+	preprodBLSOperatorStateRetrieverAddress = "0x003497Dd77E5B73C40e8aCbB562C8bb0410320E7"
 
-	disperserTestnetHostname   = "disperser-testnet-holesky.eigenda.xyz"
-	testnetCertVerifierAddress = "0xFe52fE1940858DCb6e12153E2104aD0fDFbE1162"
-	testnetSvcManagerAddress   = "0xD4A7E1Bd8015057293f0D0A557088c286942e84b"
+	disperserTestnetHostname                = "disperser-testnet-holesky.eigenda.xyz"
+	testnetCertVerifierAddress              = "0xFe52fE1940858DCb6e12153E2104aD0fDFbE1162"
+	testnetSvcManagerAddress                = "0xD4A7E1Bd8015057293f0D0A557088c286942e84b"
+	testnetBLSOperatorStateRetrieverAddress = "0x003497Dd77E5B73C40e8aCbB562C8bb0410320E7"
 )
 
 var (
@@ -151,6 +153,7 @@ type TestConfig struct {
 	BackendsToEnable []common.EigenDABackend
 	DispersalBackend common.EigenDABackend
 	Backend          Backend
+	Retrievers       []common.RetrieverType
 	Expiration       time.Duration
 	MaxBlobLength    string
 	WriteThreadCount int
@@ -180,6 +183,7 @@ func NewTestConfig(
 		BackendsToEnable:   backendsToEnable,
 		DispersalBackend:   dispersalBackend,
 		Backend:            backend,
+		Retrievers:         []common.RetrieverType{common.RelayRetrieverType, common.ValidatorRetrieverType},
 		Expiration:         14 * 24 * time.Hour,
 		UseKeccak256ModeS3: false,
 		UseS3Caching:       false,
@@ -249,6 +253,7 @@ func BuildTestSuiteConfig(testCfg TestConfig) config.AppConfig {
 	var disperserHostname string
 	var certVerifierAddress string
 	var svcManagerAddress string
+	var blsOperatorStateRetrieverAddress string
 	switch testCfg.Backend {
 	case MemstoreBackend:
 		break // no need to set these fields for local tests
@@ -256,19 +261,19 @@ func BuildTestSuiteConfig(testCfg TestConfig) config.AppConfig {
 		disperserHostname = disperserPreprodHostname
 		certVerifierAddress = preprodCertVerifierAddress
 		svcManagerAddress = preprodSvcManagerAddress
+		blsOperatorStateRetrieverAddress = preprodBLSOperatorStateRetrieverAddress
 	case TestnetBackend:
 		disperserHostname = disperserTestnetHostname
 		certVerifierAddress = testnetCertVerifierAddress
 		svcManagerAddress = testnetSvcManagerAddress
+		blsOperatorStateRetrieverAddress = testnetBLSOperatorStateRetrieverAddress
 	default:
 		panic("Unsupported backend")
 	}
-
 	payloadClientConfig := clientsv2.PayloadClientConfig{
 		PayloadPolynomialForm: codecs.PolynomialFormEval,
 		BlobVersion:           0,
 	}
-
 	proxyConfig := config.ProxyConfig{
 		ServerConfig: config.ServerConfig{
 			Host: host,
@@ -319,7 +324,7 @@ func BuildTestSuiteConfig(testCfg TestConfig) config.AppConfig {
 			PayloadDisperserCfg: payloaddispersal.PayloadDisperserConfig{
 				PayloadClientConfig:    payloadClientConfig,
 				DisperseBlobTimeout:    5 * time.Minute,
-				BlobCertifiedTimeout:   5 * time.Minute,
+				BlobCompleteTimeout:    5 * time.Minute,
 				BlobStatusPollInterval: 1 * time.Second,
 				ContractCallTimeout:    5 * time.Second,
 			},
@@ -327,9 +332,12 @@ func BuildTestSuiteConfig(testCfg TestConfig) config.AppConfig {
 				PayloadClientConfig: payloadClientConfig,
 				RelayTimeout:        5 * time.Second,
 			},
-			PutRetries:                 3,
-			MaxBlobSizeBytes:           maxBlobLengthBytes,
-			EigenDACertVerifierAddress: certVerifierAddress,
+			PutRetries:                    3,
+			MaxBlobSizeBytes:              maxBlobLengthBytes,
+			EigenDACertVerifierAddress:    certVerifierAddress,
+			BLSOperatorStateRetrieverAddr: blsOperatorStateRetrieverAddress,
+			EigenDAServiceManagerAddr:     svcManagerAddress,
+			RetrieversToEnable:            testCfg.Retrievers,
 		},
 		StorageConfig: store.Config{
 			AsyncPutWorkers:  testCfg.WriteThreadCount,
@@ -337,13 +345,11 @@ func BuildTestSuiteConfig(testCfg TestConfig) config.AppConfig {
 			DispersalBackend: testCfg.DispersalBackend,
 		},
 	}
-
 	if useMemory {
 		proxyConfig.ClientConfigV1.EdaClientCfg.SignerPrivateKeyHex =
 			"0000000000000000000100000000000000000000000000000000000000000000"
 		proxyConfig.ClientConfigV1.EdaClientCfg.SvcManagerAddr = "0x00000000069"
 	}
-
 	switch {
 	case testCfg.UseKeccak256ModeS3:
 		proxyConfig.StorageConfig = createS3Config(proxyConfig.StorageConfig)
@@ -357,26 +363,22 @@ func BuildTestSuiteConfig(testCfg TestConfig) config.AppConfig {
 		proxyConfig.StorageConfig.CacheTargets = []string{"redis"}
 		proxyConfig.StorageConfig = createRedisConfig(proxyConfig.StorageConfig)
 	}
-
 	secretConfig := common.SecretConfigV2{
 		SignerPaymentKey: pk,
 		EthRPCURL:        ethRPC,
 	}
-
 	return config.AppConfig{
 		EigenDAConfig: proxyConfig,
 		SecretConfig:  secretConfig,
 		MetricsConfig: proxy_metrics.Config{},
 	}
 }
-
 func createS3Bucket(bucketName string) {
 	// Initialize minio client object.
 	endpoint := minioEndpoint
 	accessKeyID := minioAdmin
 	secretAccessKey := minioAdmin
 	useSSL := false
-
 	minioClient, err := minio.New(
 		endpoint, &minio.Options{
 			Creds:  credentials.NewStaticV4(accessKeyID, secretAccessKey, ""),
@@ -385,9 +387,7 @@ func createS3Bucket(bucketName string) {
 	if err != nil {
 		panic(err)
 	}
-
 	location := "us-east-1"
-
 	ctx := context.Background()
 	err = minioClient.MakeBucket(ctx, bucketName, minio.MakeBucketOptions{Region: location})
 	if err != nil {
@@ -402,7 +402,6 @@ func createS3Bucket(bucketName string) {
 		log.Info(fmt.Sprintf("Successfully created %s\n", bucketName))
 	}
 }
-
 func RandStr(n int) string {
 	var letterRunes = []rune("abcdefghijklmnopqrstuvwxyz")
 	b := make([]rune, n)
@@ -411,7 +410,6 @@ func RandStr(n int) string {
 	}
 	return string(b)
 }
-
 func RandBytes(n int) []byte {
 	return []byte(RandStr(n))
 }

--- a/verify/verifier.go
+++ b/verify/verifier.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/Layr-Labs/eigenda/encoding/kzg"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark-crypto/ecc/bn254"
@@ -15,7 +14,6 @@ import (
 
 	"github.com/Layr-Labs/eigenda/api/grpc/common"
 	"github.com/Layr-Labs/eigenda/api/grpc/disperser"
-	"github.com/Layr-Labs/eigenda/encoding"
 	kzgverifier "github.com/Layr-Labs/eigenda/encoding/kzg/verifier"
 	"github.com/Layr-Labs/eigenda/encoding/rs"
 )
@@ -56,7 +54,7 @@ type Verifier struct {
 	holesky bool
 }
 
-func NewVerifier(cfg *Config, kzgConfig kzg.KzgConfig, l logging.Logger) (*Verifier, error) {
+func NewVerifier(cfg *Config, kzgVerifier *kzgverifier.Verifier, l logging.Logger) (*Verifier, error) {
 	var cv *CertVerifier
 	var err error
 
@@ -71,18 +69,6 @@ func NewVerifier(cfg *Config, kzgConfig kzg.KzgConfig, l logging.Logger) (*Verif
 			cfg.EthConfirmationDepth)
 	} else {
 		log.Warn("Certificate verification against Ethereum state disabled")
-	}
-
-	// The verifier doesn't support loading trailing g2 points from a separate file. If LoadG2Points is true, and
-	// the user is using a slimmed down g2 SRS file, the verifier will encounter an error while trying to load g2
-	// points. Since the verifier doesn't actually need g2 points, it's safe to force LoadG2Points to false, to
-	// sidestep the issue entirely.
-	kzgConfig.LoadG2Points = false
-
-	log.Info("Creating blob KZG verifier")
-	kzgVerifier, err := kzgverifier.NewVerifier(&kzgConfig, encoding.DefaultConfig())
-	if err != nil {
-		return nil, fmt.Errorf("failed to create kzg verifier: %w", err)
 	}
 
 	return &Verifier{

--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Layr-Labs/eigenda/api/clients/codecs"
 	"github.com/Layr-Labs/eigenda/api/grpc/common"
 	"github.com/Layr-Labs/eigenda/encoding/kzg"
+	kzgverifier "github.com/Layr-Labs/eigenda/encoding/kzg/verifier"
 	"github.com/Layr-Labs/eigenda/encoding/rs"
 	"github.com/stretchr/testify/require"
 )
@@ -38,13 +39,17 @@ func TestCommitmentVerification(t *testing.T) {
 		SRSOrder:        3000,
 		SRSNumberToLoad: 3000,
 		NumWorker:       uint64(runtime.GOMAXPROCS(0)),
+		LoadG2Points:    false,
 	}
+
+	kzgVerifier, err := kzgverifier.NewVerifier(&kzgConfig, nil)
+	require.NoError(t, err)
 
 	cfg := &Config{
 		VerifyCerts: false,
 	}
 
-	v, err := NewVerifier(cfg, kzgConfig, nil)
+	v, err := NewVerifier(cfg, kzgVerifier, nil)
 	require.NoError(t, err)
 
 	// Happy path verification
@@ -76,13 +81,17 @@ func TestCommitmentWithTooLargeBlob(t *testing.T) {
 		SRSOrder:        3000,
 		SRSNumberToLoad: 3000,
 		NumWorker:       uint64(runtime.GOMAXPROCS(0)),
+		LoadG2Points:    false,
 	}
+
+	kzgVerifier, err := kzgverifier.NewVerifier(&kzgConfig, nil)
+	require.NoError(t, err)
 
 	cfg := &Config{
 		VerifyCerts: false,
 	}
 
-	v, err := NewVerifier(cfg, kzgConfig, nil)
+	v, err := NewVerifier(cfg, kzgVerifier, nil)
 	require.NoError(t, err)
 
 	// Some wrong commitment just to pass in function


### PR DESCRIPTION
- closes DAINT-322
    - [link](https://linear.app/eigenlabs/issue/DAINT-322/v2-optional-distributed-retrieval-w-eigenda-operator-set) 
- closes EGDA-1094
    - [link](https://linear.app/eigenlabs/issue/EGDA-1094/add-optional-network-id-flag-to-populate-other-config-fields)  

DO NOT MERGE:
- Given that we have recently released V2 proxy support, it's likely we will need to release patches in the near future
- This PR update the eigenda core dependency to the latest `master` commit, since doing so is required to implement blob retrieval from validator nodes.
- proxy releases should only be made with a dependency on an official core release. Until a new core release is cut which includes the necessary changes to support distributed retrieval, this PR will need to remain as a feature branch

## Flag Changes

The following new *V2* flags are introduced:

```
		&cli.StringFlag{
			Name:     ServiceManagerAddrFlagName,
			Usage:    "Address of the EigenDA service manager contract.",
			EnvVars:  []string{withEnvPrefix(envPrefix, "SERVICE_MANAGER_ADDR")},
			Category: category,
			Required: false,
		},
		&cli.StringFlag{
			Name:     BLSOperatorStateRetrieverFlagName,
			Usage:    "Address of the BLS operator state retriever contract.",
			EnvVars:  []string{withEnvPrefix(envPrefix, "BLS_OPERATOR_STATE_RETRIEVER_ADDR")},
			Category: category,
			Required: false,
		},
		&cli.DurationFlag{
			Name: ValidatorTimeoutFlagName,
			Usage: "Timeout used when retrieving chunks directly from EigenDA validators. " +
				"This is a secondary retrieval method, in case retrieval from the relay network fails.",
			EnvVars:  []string{withEnvPrefix(envPrefix, "VALIDATOR_TIMEOUT")},
			Category: category,
			Value:    2 * time.Minute,
			Required: false,
		},
```