### PR TITLE
Support Enabling CORS on Proxy

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -169,7 +169,7 @@ linters:
     - rowserrcheck # checks whether Err of rows is checked successfully
     - sqlclosecheck # checks that sql.Rows and sql.Stmt are closed
     - stylecheck # is a replacement for golint
-    - usetesting
+    - tenv  # using tenv instead of usetesting
     - testableexamples # checks if examples are testable (have an expected output)
     - testpackage # makes you use a separate _test package
     - tparallel # detects inappropriate usage of t.Parallel() method in your Go test codes

--- a/README.md
+++ b/README.md
@@ -316,13 +316,7 @@ When CORS is enabled, the proxy will:
 2. Add CORS headers to all API responses
 3. Allow browsers to make cross-origin requests to the proxy API endpoints
 
-OPTIONS requests (known as "preflight requests") are a crucial part of the CORS security model. When a web application makes certain types of cross-origin requests (like those using certain HTTP methods or custom headers), browsers automatically send an OPTIONS request first to check if the server allows the actual request. This is a security mechanism built into browsers that:
-
-1. Helps protect servers from unexpected cross-origin requests
-2. Allows servers to specify which origins, methods, and headers are permitted
-3. Prevents potentially harmful operations from being executed without server approval
-
-For example, when a JavaScript client on website A.com tries to make a POST request with JSON data to our proxy on B.com, the browser first sends an OPTIONS request to verify that this cross-origin POST is allowed. Our proxy needs to respond appropriately to these OPTIONS requests for browser-based clients to work correctly.
+OPTIONS requests (known as "preflight requests") are a crucial part of the CORS security model. For more information on this part of the CORS model, see the following [resource](http://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS#preflighted_requests).
 
 ### Requirements / Dependencies
 

--- a/README.md
+++ b/README.md
@@ -296,6 +296,28 @@ In the event that the EigenDA disperser or network is down, the proxy will retur
 
 This behavior is turned on by default, but configurable via the `--eigenda.confirmation-timeout` flag (set to 15 mins by default currently). If a blob is not confirmed within this time, the proxy will return a 503 status code. This should be set long enough to accomodate for the disperser's batching interval (typically 10 minutes), signature gathering, and onchain submission.
 
+#### CORS Support <!-- omit from toc -->
+The proxy can be configured to support Cross-Origin Resource Sharing (CORS), enabling web applications to make requests to the proxy server from different origins. This is useful for JavaScript clients or web applications that need to interact with the proxy directly from the browser.
+
+To enable CORS, use the following CLI flag:
+- `--cors-allowed-domains`: A comma-separated list of domains to allow CORS from (e.g., `google.com,localhost:4157`). Use `*` to allow all origins.
+
+Example usage:
+```bash
+# Allow CORS from any origin
+./bin/eigenda-proxy --cors-allowed-domains="*"
+
+# Allow CORS only from specific domains
+./bin/eigenda-proxy --cors-allowed-domains="myapp.com,localhost:3000"
+```
+
+When CORS is enabled, the proxy will:
+1. Respond to preflight OPTIONS requests with appropriate CORS headers
+2. Add CORS headers to all API responses
+3. Properly handle credentials and custom headers in cross-origin requests
+
+OPTIONS requests are required by browsers to handle custom headers and non-simple HTTP methods according to the CORS specification. The proxy handles these preflight requests automatically.
+
 ### Requirements / Dependencies
 
 #### Authn/Authz/Payments

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ Example usage:
 When CORS is enabled, the proxy will:
 1. Respond to preflight OPTIONS requests with appropriate CORS headers
 2. Add CORS headers to all API responses
-3. Properly handle credentials and custom headers in cross-origin requests
+3. Allow browsers to make cross-origin requests to the proxy API endpoints
 
 OPTIONS requests are required by browsers to handle custom headers and non-simple HTTP methods according to the CORS specification. The proxy handles these preflight requests automatically.
 

--- a/README.md
+++ b/README.md
@@ -316,7 +316,13 @@ When CORS is enabled, the proxy will:
 2. Add CORS headers to all API responses
 3. Allow browsers to make cross-origin requests to the proxy API endpoints
 
-OPTIONS requests are required by browsers to handle custom headers and non-simple HTTP methods according to the CORS specification. The proxy handles these preflight requests automatically.
+OPTIONS requests (known as "preflight requests") are a crucial part of the CORS security model. When a web application makes certain types of cross-origin requests (like those using certain HTTP methods or custom headers), browsers automatically send an OPTIONS request first to check if the server allows the actual request. This is a security mechanism built into browsers that:
+
+1. Helps protect servers from unexpected cross-origin requests
+2. Allows servers to specify which origins, methods, and headers are permitted
+3. Prevents potentially harmful operations from being executed without server approval
+
+For example, when a JavaScript client on website A.com tries to make a POST request with JSON data to our proxy on B.com, the browser first sends an OPTIONS request to verify that this cross-origin POST is allowed. Our proxy needs to respond appropriately to these OPTIONS requests for browser-based clients to work correctly.
 
 ### Requirements / Dependencies
 

--- a/config/flags.go
+++ b/config/flags.go
@@ -31,10 +31,11 @@ const (
 )
 
 const (
-	ListenAddrFlagName  = "addr"
-	PortFlagName        = "port"
-	APIsEnabledFlagName = "api-enabled"
-	AdminAPIType        = "admin"
+	ListenAddrFlagName         = "addr"
+	PortFlagName               = "port"
+	APIsEnabledFlagName        = "api-enabled"
+	CORSAllowedDomainsFlagName = "cors-allowed-domains"
+	AdminAPIType               = "admin"
 )
 
 func CLIFlags(envPrefix string, category string) []cli.Flag {
@@ -59,6 +60,13 @@ func CLIFlags(envPrefix string, category string) []cli.Flag {
 			Usage:    "List of API types to enable (e.g. admin)",
 			Value:    cli.NewStringSlice(),
 			EnvVars:  common.PrefixEnvVar(envPrefix, "API_ENABLED"),
+			Category: category,
+		},
+		&cli.StringSliceFlag{
+			Name:     CORSAllowedDomainsFlagName,
+			Usage:    "List of domains allowed for CORS (e.g. google.com,localhost:4157). Use '*' to allow all origins.",
+			Value:    cli.NewStringSlice(),
+			EnvVars:  common.PrefixEnvVar(envPrefix, "CORS_ALLOWED_DOMAINS"),
 			Category: category,
 		},
 	}

--- a/config/proxy_config.go
+++ b/config/proxy_config.go
@@ -76,9 +76,10 @@ func ReadProxyConfig(ctx *cli.Context) (ProxyConfig, error) {
 
 	cfg := ProxyConfig{
 		ServerConfig: ServerConfig{
-			Host:        ctx.String(ListenAddrFlagName),
-			Port:        ctx.Int(PortFlagName),
-			EnabledAPIs: ctx.StringSlice(APIsEnabledFlagName),
+			Host:               ctx.String(ListenAddrFlagName),
+			Port:               ctx.Int(PortFlagName),
+			EnabledAPIs:        ctx.StringSlice(APIsEnabledFlagName),
+			CORSAllowedDomains: ctx.StringSlice(CORSAllowedDomainsFlagName),
 		},
 		ClientConfigV1:   clientConfigV1,
 		VerifierConfigV1: verifierConfigV1,

--- a/config/server_config.go
+++ b/config/server_config.go
@@ -13,6 +13,10 @@ type ServerConfig struct {
 	// Example: If it contains "admin", administrative endpoints like
 	// /admin/eigenda-dispersal-backend will be available.
 	EnabledAPIs []string
+	// CORSAllowedDomains is a list of domains allowed for CORS requests.
+	// When list contains "*", all origins are allowed.
+	// When empty, CORS is disabled.
+	CORSAllowedDomains []string
 }
 
 // IsAPIEnabled checks if a specific API type is enabled

--- a/docs/help_out.txt
+++ b/docs/help_out.txt
@@ -108,9 +108,10 @@ optional and will be skipped when set to 0. (default: 0) [$EIGENDA_PROXY_EIGENDA
 
    Proxy Server
 
-   --addr value                                 Server listening address (default: "0.0.0.0") [$EIGENDA_PROXY_ADDR]
-   --api-enabled value [ --api-enabled value ]  List of API types to enable (e.g. admin) [$EIGENDA_PROXY_API_ENABLED]
-   --port value                                 Server listening port (default: 3100) [$EIGENDA_PROXY_PORT]
+   --addr value                                                   Server listening address (default: "0.0.0.0") [$EIGENDA_PROXY_ADDR]
+   --api-enabled value [ --api-enabled value ]                    List of API types to enable (e.g. admin) [$EIGENDA_PROXY_API_ENABLED]
+   --cors-allowed-domains value [ --cors-allowed-domains value ]  List of domains allowed for CORS (e.g. google.com,localhost:4157). Use '*' to allow all origins. [$EIGENDA_PROXY_CORS_ALLOWED_DOMAINS]
+   --port value                                                   Server listening port (default: 3100) [$EIGENDA_PROXY_PORT]
 
    Redis Cache/Fallback
 

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/Layr-Labs/eigenda-proxy/common/types/commitments"
+	"github.com/Layr-Labs/eigenda-proxy/config"
 	"github.com/Layr-Labs/eigenda-proxy/metrics"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 )
@@ -100,5 +102,84 @@ func withLogging(
 			args = append(args, "commitment_mode", getErr.Mode, "cert_version", getErr.CertVersion)
 		}
 		log.Info("request", args...)
+	}
+}
+
+// withCORS is a middleware that adds CORS headers to responses.
+// It intercepts OPTIONS requests for handling CORS preflight requests.
+// OPTIONS requests are needed to support cross-origin requests that use custom
+// headers or methods other than simple methods (GET, POST).
+func withCORS(
+	handleFn func(http.ResponseWriter, *http.Request),
+	corsConfig config.ServerConfig,
+	log logging.Logger,
+) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// If CORS domains list is empty, CORS is disabled
+		if len(corsConfig.CORSAllowedDomains) == 0 {
+			handleFn(w, r)
+			return
+		}
+
+		origin := r.Header.Get("Origin")
+		if origin == "" {
+			// Not a CORS request
+			handleFn(w, r)
+			return
+		}
+
+		// Check if origin is allowed
+		allowOrigin := ""
+		allowAllOrigins := false
+
+		// Check if wildcard is used
+		for _, domain := range corsConfig.CORSAllowedDomains {
+			trimmedDomain := strings.TrimSpace(domain)
+			if trimmedDomain == "*" {
+				allowAllOrigins = true
+				break
+			}
+		}
+
+		if allowAllOrigins {
+			allowOrigin = "*"
+		} else {
+			// Check for specific domain match
+			allowed := false
+			for _, domain := range corsConfig.CORSAllowedDomains {
+				trimmedDomain := strings.TrimSpace(domain)
+				// Exact match or domain match (subdomain handling)
+				if trimmedDomain == origin ||
+					// Match pattern like "example.com" against "subdomain.example.com"
+					strings.HasSuffix(origin, "."+trimmedDomain) ||
+					// Match exact subdomain like "app.example.com" against "app.example.com"
+					origin == trimmedDomain {
+					allowed = true
+					allowOrigin = origin // Use the actual origin for specific domain matches
+					break
+				}
+			}
+
+			if !allowed {
+				log.Info("CORS rejected", "origin", origin)
+				handleFn(w, r)
+				return
+			}
+		}
+
+		// Set CORS headers
+		w.Header().Set("Access-Control-Allow-Origin", allowOrigin)
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers",
+			"Content-Type, Accept, Content-Length, Accept-Encoding, Authorization")
+
+		// Handle preflight request (OPTIONS method is used for preflight CORS requests)
+		if r.Method == "OPTIONS" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		// Call the actual handler
+		handleFn(w, r)
 	}
 }

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -174,7 +174,7 @@ func withCORS(
 			"Content-Type, Accept, Content-Length, Accept-Encoding, Authorization")
 
 		// Handle preflight request (OPTIONS method is used for preflight CORS requests)
-		if r.Method == "OPTIONS" {
+		if r.Method == http.MethodOptions {
 			w.WriteHeader(http.StatusOK)
 			return
 		}

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -144,16 +144,12 @@ func withCORS(
 		if allowAllOrigins {
 			allowOrigin = "*"
 		} else {
-			// Check for specific domain match
+			// Check for specific domain match - exact matches only
 			allowed := false
 			for _, domain := range corsConfig.CORSAllowedDomains {
 				trimmedDomain := strings.TrimSpace(domain)
-				// Exact match or domain match (subdomain handling)
-				if trimmedDomain == origin ||
-					// Match pattern like "example.com" against "subdomain.example.com"
-					strings.HasSuffix(origin, "."+trimmedDomain) ||
-					// Match exact subdomain like "app.example.com" against "app.example.com"
-					origin == trimmedDomain {
+				// Only match exact domains
+				if trimmedDomain == origin {
 					allowed = true
 					allowOrigin = origin // Use the actual origin for specific domain matches
 					break


### PR DESCRIPTION
Adds flags to facilitate CORS:

- `--cors-allowed-domains <domain1>,<domain2>,<domain3>` which allows enabling CORS for a subset of domains. Can also specify "*" to allow all domains.