### PR TITLE
feat: Use most recent core commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,11 +34,11 @@ test-e2e-local:
 # E2E tests using holesky testnet backend, leveraging op-e2e framework. Also tests the standard client against the proxy.
 # If holesky tests are failing, consider checking https://dora.holesky.ethpandaops.io/epochs for block production status.
 test-e2e-testnet:
-	BACKEND=testnet gotestsum --format testname -- -v -timeout 40m ./e2e -parallel 32
+	BACKEND=testnet gotestsum --format testname -- -v -timeout 20m ./e2e -parallel 32
 
 ## Equivalent to `test-e2e-testnet`, but against preprod instead of testnet
 test-e2e-preprod:
-	BACKEND=preprod gotestsum --format testname -- -v -timeout 40m ./e2e -parallel 32
+	BACKEND=preprod gotestsum --format testname -- -v -timeout 20m ./e2e -parallel 32
 
 # Very simple fuzzer which generates random bytes arrays and sends them to the proxy using the standard client.
 # To clean the cached corpus, run `go clean -fuzzcache` before running this.

--- a/Makefile
+++ b/Makefile
@@ -34,11 +34,11 @@ test-e2e-local:
 # E2E tests using holesky testnet backend, leveraging op-e2e framework. Also tests the standard client against the proxy.
 # If holesky tests are failing, consider checking https://dora.holesky.ethpandaops.io/epochs for block production status.
 test-e2e-testnet:
-	BACKEND=testnet gotestsum --format testname -- -v -timeout 20m ./e2e -parallel 32
+	BACKEND=testnet gotestsum --format testname -- -v -timeout 40m ./e2e -parallel 32
 
 ## Equivalent to `test-e2e-testnet`, but against preprod instead of testnet
 test-e2e-preprod:
-	BACKEND=preprod gotestsum --format testname -- -v -timeout 20m ./e2e -parallel 32
+	BACKEND=preprod gotestsum --format testname -- -v -timeout 40m ./e2e -parallel 32
 
 # Very simple fuzzer which generates random bytes arrays and sends them to the proxy using the standard client.
 # To clean the cached corpus, run `go clean -fuzzcache` before running this.

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.22.7
 
 require (
-	github.com/Layr-Labs/eigenda v0.9.1-0.20250411174037-b6b545d7cbf6
+	github.com/Layr-Labs/eigenda v0.9.1-0.20250520184231-dbc01a215a28
 	github.com/Layr-Labs/eigenda-proxy/clients v0.0.0-00010101000000-000000000000
 	github.com/Layr-Labs/eigensdk-go v0.2.0-beta.1.0.20250118004418-2a25f31b3b28
 	github.com/avast/retry-go/v4 v4.6.0
@@ -61,6 +61,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.23.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.6 // indirect
 	github.com/aws/smithy-go v1.20.2 // indirect
+	github.com/beevik/ntp v1.4.3 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.13.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/DataDog/zstd v1.5.6-0.20230824185856-869dae002e5e h1:ZIWapoIRN1VqT8GR
 github.com/DataDog/zstd v1.5.6-0.20230824185856-869dae002e5e/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/Layr-Labs/cerberus-api v0.0.2-0.20250117193600-e69c5e8b08fd h1:prMzW4BY6KZtWEanf5EIsyHzIZKCNV2mVIXrE6glRRM=
 github.com/Layr-Labs/cerberus-api v0.0.2-0.20250117193600-e69c5e8b08fd/go.mod h1:Lm4fhzy0S3P7GjerzuseGaBFVczsIKmEhIjcT52Hluo=
-github.com/Layr-Labs/eigenda v0.9.1-0.20250411174037-b6b545d7cbf6 h1:ZWwH1IEFNdVER84yfVM72WROwsUVoSpHA5jFBFaQa6o=
-github.com/Layr-Labs/eigenda v0.9.1-0.20250411174037-b6b545d7cbf6/go.mod h1:MO3EyBXCmhzttrmmgqmIkzDg4gtqWjU+0fxSN0Q1EmM=
+github.com/Layr-Labs/eigenda v0.9.1-0.20250520184231-dbc01a215a28 h1:nRBenEtqU33waClKFIxGyzPasOIMSTSE/4so9fKPsTo=
+github.com/Layr-Labs/eigenda v0.9.1-0.20250520184231-dbc01a215a28/go.mod h1:hu6R6zj6bOtZwbkLSNJN5m/I06XSwSZjQrCTIqOhyPo=
 github.com/Layr-Labs/eigensdk-go v0.2.0-beta.1.0.20250118004418-2a25f31b3b28 h1:Wig5FBBizIB5Z/ZcXJlm7KdOLnrXc6E3DjO63uWRzQM=
 github.com/Layr-Labs/eigensdk-go v0.2.0-beta.1.0.20250118004418-2a25f31b3b28/go.mod h1:YNzORpoebdDNv0sJLm/H9LTx72M85zA54eBSXI5DULw=
 github.com/Layr-Labs/eigensdk-go/signer v0.0.0-20250118004418-2a25f31b3b28 h1:rhIC2XpFpCcRkv4QYczIUe/fXvE4T+0B1mF9f6NJCuo=
@@ -103,6 +103,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.28.6 h1:cwIxeBttqPN3qkaAjcEcsh8NYr8n
 github.com/aws/aws-sdk-go-v2/service/sts v1.28.6/go.mod h1:FZf1/nKNEkHdGGJP/cI2MoIMquumuRK6ol3QQJNDxmw=
 github.com/aws/smithy-go v1.20.2 h1:tbp628ireGtzcHDDmLT/6ADHidqnwgF57XOXZe6tp4Q=
 github.com/aws/smithy-go v1.20.2/go.mod h1:krry+ya/rV9RDcV/Q16kpu6ypI4K2czasz0NC3qS14E=
+github.com/beevik/ntp v1.4.3 h1:PlbTvE5NNy4QHmA4Mg57n7mcFTmr1W1j3gcK7L1lqho=
+github.com/beevik/ntp v1.4.3/go.mod h1:Unr8Zg+2dRn7d8bHFuehIMSvvUYssHMxW3Q5Nx4RW5Q=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz5o=

--- a/store/generated_key/memstore/v2/memstore.go
+++ b/store/generated_key/memstore/v2/memstore.go
@@ -16,7 +16,7 @@ import (
 	"github.com/Layr-Labs/eigenda-proxy/store/generated_key/memstore/memconfig"
 	"github.com/Layr-Labs/eigenda/api/clients/codecs"
 	"github.com/Layr-Labs/eigenda/api/clients/v2/verification"
-	cert_verifier_binding "github.com/Layr-Labs/eigenda/contracts/bindings/EigenDACertVerifier"
+	cert_verifier_binding "github.com/Layr-Labs/eigenda/contracts/bindings/EigenDACertVerifierV2"
 
 	"github.com/Layr-Labs/eigensdk-go/logging"
 )
@@ -97,12 +97,12 @@ func (e *MemStore) generateRandomCert(blobContents []byte) (*coretypes.EigenDACe
 		Y: y,
 	}
 
-	pseudoRandomBlobInclusionInfo := cert_verifier_binding.BlobInclusionInfo{
-		BlobCertificate: cert_verifier_binding.BlobCertificate{
-			BlobHeader: cert_verifier_binding.BlobHeaderV2{
+	pseudoRandomBlobInclusionInfo := cert_verifier_binding.EigenDATypesV2BlobInclusionInfo{
+		BlobCertificate: cert_verifier_binding.EigenDATypesV2BlobCertificate{
+			BlobHeader: cert_verifier_binding.EigenDATypesV2BlobHeaderV2{
 				Version:       0,                            // only supported version as of now
 				QuorumNumbers: []byte{byte(0x0), byte(0x1)}, // quorum 0 && quorum 1
-				Commitment: cert_verifier_binding.BlobCommitment{
+				Commitment: cert_verifier_binding.EigenDATypesV2BlobCommitment{
 					LengthCommitment: cert_verifier_binding.BN254G2Point{
 						X: [2]*big.Int{unsafeRandInt(1000), unsafeRandInt(1000)},
 						Y: [2]*big.Int{unsafeRandInt(1000), unsafeRandInt(1000)},
@@ -125,12 +125,12 @@ func (e *MemStore) generateRandomCert(blobContents []byte) (*coretypes.EigenDACe
 		InclusionProof: unsafeRandomBytes(128),
 	}
 
-	randomBatchHeader := cert_verifier_binding.BatchHeaderV2{
+	randomBatchHeader := cert_verifier_binding.EigenDATypesV2BatchHeaderV2{
 		BatchRoot:            [32]byte(unsafeRandomBytes(32)),
 		ReferenceBlockNumber: unsafeRandUint32(),
 	}
 
-	randomNonSignerStakesAndSigs := cert_verifier_binding.NonSignerStakesAndSignature{
+	randomNonSignerStakesAndSigs := cert_verifier_binding.EigenDATypesV1NonSignerStakesAndSignature{
 		NonSignerQuorumBitmapIndices: []uint32{unsafeRandUint32(), unsafeRandUint32()},
 		NonSignerPubkeys: []cert_verifier_binding.BN254G1Point{
 			{

--- a/verify/cert.go
+++ b/verify/cert.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/Layr-Labs/eigenda-proxy/common/consts"
 	"github.com/Layr-Labs/eigenda/api/grpc/disperser"
-	binding "github.com/Layr-Labs/eigenda/contracts/bindings/EigenDACertVerifier"
 	edsm_binding "github.com/Layr-Labs/eigenda/contracts/bindings/EigenDAServiceManager"
+	binding "github.com/Layr-Labs/eigenda/contracts/bindings/IEigenDACertVerifierLegacy"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 
 	"github.com/ethereum-optimism/optimism/op-service/retry"
@@ -117,7 +117,7 @@ func (cv *CertVerifier) verifyBatchConfirmedOnChain(
 	}
 
 	// 2. Compute the hash of the batch metadata received as argument.
-	header := &binding.BatchHeader{
+	header := &binding.EigenDATypesV1BatchHeader{
 		BlobHeadersRoot:       [32]byte(batchMetadata.GetBatchHeader().GetBatchRoot()),
 		QuorumNumbers:         batchMetadata.GetBatchHeader().GetQuorumNumbers(),
 		ReferenceBlockNumber:  batchMetadata.GetBatchHeader().GetReferenceBlockNumber(),

--- a/verify/hasher.go
+++ b/verify/hasher.go
@@ -3,7 +3,7 @@ package verify
 import (
 	"encoding/binary"
 
-	binding "github.com/Layr-Labs/eigenda/contracts/bindings/EigenDACertVerifier"
+	binding "github.com/Layr-Labs/eigenda/contracts/bindings/IEigenDACertVerifierLegacy"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	geth_common "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -12,7 +12,11 @@ import (
 // HashBatchMetadata regenerates a batch data hash
 // replicates:
 // https://github.com/Layr-Labs/eigenda-utils/blob/c4cbc9ec078aeca3e4a04bd278e2fb136bf3e6de/src/libraries/EigenDAHasher.sol#L46-L54
-func HashBatchMetadata(bh *binding.BatchHeader, sigHash [32]byte, confirmedBlockNum uint32) (geth_common.Hash, error) {
+func HashBatchMetadata(
+	bh *binding.EigenDATypesV1BatchHeader,
+	sigHash [32]byte,
+	confirmedBlockNum uint32,
+) (geth_common.Hash, error) {
 	batchHeaderType, err := abi.NewType("tuple", "", []abi.ArgumentMarshaling{
 		{
 			Name: "blobHeadersRoot",

--- a/verify/hasher_test.go
+++ b/verify/hasher_test.go
@@ -6,7 +6,7 @@ import (
 
 	eigenda_common "github.com/Layr-Labs/eigenda/api/grpc/common"
 	"github.com/Layr-Labs/eigenda/api/grpc/disperser"
-	binding "github.com/Layr-Labs/eigenda/contracts/bindings/EigenDACertVerifier"
+	binding "github.com/Layr-Labs/eigenda/contracts/bindings/IEigenDACertVerifierLegacy"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
 )
@@ -46,7 +46,7 @@ func TestHashBatchHashedMetadata(t *testing.T) {
 func TestHashBatchMetadata(t *testing.T) {
 	testHash := crypto.Keccak256Hash([]byte("batchHeader"))
 
-	header := &binding.BatchHeader{
+	header := &binding.EigenDATypesV1BatchHeader{
 		BlobHeadersRoot:       testHash,
 		QuorumNumbers:         testHash.Bytes(),
 		SignedStakeForQuorums: testHash.Bytes(),


### PR DESCRIPTION
- Updates to the most recent core commit, to be able to make a proxy release candidate
- I wasn't able to point to the exact `v0.9.0-rc.3` core tag, since that commit is missing the v1 bindings, which weren't added back in until core commit `dbc01a215a2811a8d4c30178b892dbd44694fc5b`, which is what I had to use