### PR TITLE
improve: increase rbn for memstore v2

### DIFF
--- a/store/generated_key/memstore/v2/memstore.go
+++ b/store/generated_key/memstore/v2/memstore.go
@@ -45,7 +45,7 @@ func unsafeRandInt(maxValue int64) *big.Int {
 	return randInt
 }
 
-func unsafeRandUint32() uint32 {
+func unsafeRandCeilAt32() uint32 {
 	// #nosec G115 - downcasting only on random value
 	return uint32(unsafeRandInt(32).Uint64())
 }
@@ -119,7 +119,7 @@ func (e *MemStore) generateRandomCert(blobContents []byte) (coretypes.EigenDACer
 				PaymentHeaderHash: [32]byte(unsafeRandomBytes(32)),
 			},
 			Signature: unsafeRandomBytes(48), // 384 bits
-			RelayKeys: []uint32{unsafeRandUint32(), unsafeRandUint32()},
+			RelayKeys: []uint32{unsafeRandCeilAt32(), unsafeRandCeilAt32()},
 		},
 		// #nosec G115 - max value 1000 guaranteed to be safe for uint32
 		BlobIndex:      uint32(unsafeRandInt(1_000).Uint64()),
@@ -135,11 +135,11 @@ func (e *MemStore) generateRandomCert(blobContents []byte) (coretypes.EigenDACer
 		// where the check is often done by checking the failure condition
 		// certL1InclusionBlock > RecencyWindowSize + cert.RBN
 		// once we increase the RBN, the above failure condition will never trigger
-		ReferenceBlockNumber: unsafeRandUint32() + 4294967200,
+		ReferenceBlockNumber: unsafeRandCeilAt32() + 4294967200,
 	}
 
 	randomNonSignerStakesAndSigs := cert_types_binding.EigenDATypesV1NonSignerStakesAndSignature{
-		NonSignerQuorumBitmapIndices: []uint32{unsafeRandUint32(), unsafeRandUint32()},
+		NonSignerQuorumBitmapIndices: []uint32{unsafeRandCeilAt32(), unsafeRandCeilAt32()},
 		NonSignerPubkeys: []cert_types_binding.BN254G1Point{
 			{
 				X: unsafeRandInt(1000),
@@ -156,11 +156,11 @@ func (e *MemStore) generateRandomCert(blobContents []byte) (coretypes.EigenDACer
 			X: [2]*big.Int{unsafeRandInt(1000), unsafeRandInt(10000)},
 			Y: [2]*big.Int{unsafeRandInt(1000), unsafeRandInt(1000)},
 		},
-		QuorumApkIndices:  []uint32{unsafeRandUint32(), unsafeRandUint32()},
-		TotalStakeIndices: []uint32{unsafeRandUint32(), unsafeRandUint32(), unsafeRandUint32()},
+		QuorumApkIndices:  []uint32{unsafeRandCeilAt32(), unsafeRandCeilAt32()},
+		TotalStakeIndices: []uint32{unsafeRandCeilAt32(), unsafeRandCeilAt32(), unsafeRandCeilAt32()},
 		NonSignerStakeIndices: [][]uint32{
-			{unsafeRandUint32(), unsafeRandUint32()},
-			{unsafeRandUint32(), unsafeRandUint32()},
+			{unsafeRandCeilAt32(), unsafeRandCeilAt32()},
+			{unsafeRandCeilAt32(), unsafeRandCeilAt32()},
 		},
 		Sigma: cert_types_binding.BN254G1Point{
 			X: unsafeRandInt(1000),

--- a/store/generated_key/memstore/v2/memstore.go
+++ b/store/generated_key/memstore/v2/memstore.go
@@ -131,7 +131,7 @@ func (e *MemStore) generateRandomCert(blobContents []byte) (coretypes.EigenDACer
 		// increase the rbn of cert to a high enough number 4294967200 < 2^32 = 4294967296
 		// where random part is chosen from 0 to 32. So there is no chance of overflow.
 		// a large RBN is useful to avoid failing the recency check when testing
-		// See https://github.com/Layr-Labs/eigenda/blob/master/docs/spec/src/integration/spec/6-secure-integration.md#1-rbn-recency-validation
+		// See https://github.com/Layr-Labs/eigenda/blob/master/docs/spec/src/integration/spec/6-secure-integration.md
 		// where the check is often done by checking the failure condition
 		// certL1InclusionBlock > RecencyWindowSize + cert.RBN
 		// once we increase the RBN, the above failure condition will never trigger


### PR DESCRIPTION
This PR changes the rbn when used with v2 memstore

The motivation comes from a need to test OP secure integration. The hokulea is implementing the recency [check](https://github.com/Layr-Labs/hokulea/pull/121). All tests in hokulea are done with a kurtosis devnet where eigenda-proxy is configured in memstore mode.

V2 memstore currently chooses a random number from 0 to 32 for a rbn. It essentially fails all DA certs due to the recency check.

The change adds a large number to rbn while preserving the randomness. Because rbn is so large, the recency check will never fail, https://github.com/Layr-Labs/eigenda/blob/master/docs/spec/src/integration/spec/6-secure-integration.md#1-rbn-recency-validation.

Having this change allows regular and CI test on hokulea