### PR TITLE
feat: Optional EigenDACertVerifierV1 support for reading quorums/thresholds

### DIFF
--- a/docs/help_out.txt
+++ b/docs/help_out.txt
@@ -19,8 +19,9 @@ GLOBAL OPTIONS:
    Cert Verifier (V1 only)
 
    --eigenda.cert-verification-disabled  Whether to verify certificates received from EigenDA disperser. (default: false) [$EIGENDA_PROXY_EIGENDA_CERT_VERIFICATION_DISABLED]
-   --eigenda.cert-verifier-v1 value      Address of EigenDACertVerifierV1 contract. Only necessary if using custom quorums/thresholds for certificate verification.
-                                                   If no address is provided then the default EigenDAServiceManager parameters will be uesd. [$EIGENDA_PROXY_EIGENDA_CERT_VERIFIER_V1]
+   --eigenda.cert-verifier-v1 value      Address of EigenDACertVerifierV1 contract. Only necessary if using custom quorums/thresholds 
+                                                 for certificate verification. If no address is provided then the default 
+                                                 EigenDAServiceManager parameters will be uesd. [$EIGENDA_PROXY_EIGENDA_CERT_VERIFIER_V1]
 
    EigenDA V1 Client
 

--- a/docs/help_out.txt
+++ b/docs/help_out.txt
@@ -18,6 +18,7 @@ GLOBAL OPTIONS:
 
    Cert Verifier (V1 only)
 
+   --cert-verifier-v1 value              Address of EigenDACertVerifierV1 contract. Only necessary if using custom quorums/thresholds for certificate verification. [$EIGENDA_PROXY_EIGENDA_CERT_VERIFIER_V1]
    --eigenda.cert-verification-disabled  Whether to verify certificates received from EigenDA disperser. (default: false) [$EIGENDA_PROXY_EIGENDA_CERT_VERIFICATION_DISABLED]
 
    EigenDA V1 Client

--- a/docs/help_out.txt
+++ b/docs/help_out.txt
@@ -18,8 +18,9 @@ GLOBAL OPTIONS:
 
    Cert Verifier (V1 only)
 
-   --cert-verifier-v1 value              Address of EigenDACertVerifierV1 contract. Only necessary if using custom quorums/thresholds for certificate verification. [$EIGENDA_PROXY_EIGENDA_CERT_VERIFIER_V1]
    --eigenda.cert-verification-disabled  Whether to verify certificates received from EigenDA disperser. (default: false) [$EIGENDA_PROXY_EIGENDA_CERT_VERIFICATION_DISABLED]
+   --eigenda.cert-verifier-v1 value      Address of EigenDACertVerifierV1 contract. Only necessary if using custom quorums/thresholds for certificate verification.
+                                                   If no address is provided then the default EigenDAServiceManager parameters will be uesd. [$EIGENDA_PROXY_EIGENDA_CERT_VERIFIER_V1]
 
    EigenDA V1 Client
 

--- a/store/generated_key/eigenda/verify/cert.go
+++ b/store/generated_key/eigenda/verify/cert.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Layr-Labs/eigenda-proxy/common/consts"
 	"github.com/Layr-Labs/eigenda/api/grpc/disperser"
+	v1_verifier_binding "github.com/Layr-Labs/eigenda/contracts/bindings/EigenDACertVerifierV1"
 	edsm_binding "github.com/Layr-Labs/eigenda/contracts/bindings/EigenDAServiceManager"
 	binding "github.com/Layr-Labs/eigenda/contracts/bindings/IEigenDACertVerifierLegacy"
 	"github.com/Layr-Labs/eigensdk-go/logging"
@@ -21,6 +22,11 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 	"golang.org/x/exp/slices"
 )
+
+type SecurityParamReader interface {
+	QuorumAdversaryThresholdPercentages(opts *bind.CallOpts) ([]byte, error)
+	QuorumNumbersRequired(opts *bind.CallOpts) ([]uint8, error)
+}
 
 // CertVerifier verifies the DA certificate against on-chain EigenDA contracts
 // to ensure disperser returned fields haven't been tampered with
@@ -34,8 +40,10 @@ type CertVerifier struct {
 	// (typically 64 blocks in happy case).
 	ethConfirmationDepth uint64
 	waitForFinalization  bool
-	manager              *edsm_binding.ContractEigenDAServiceManagerCaller
-	ethClient            *ethclient.Client
+	svcManagerCaller     *edsm_binding.ContractEigenDAServiceManagerCaller
+
+	securityParamReader SecurityParamReader
+	ethClient           *ethclient.Client
 	// The two fields below are fetched from the EigenDAServiceManager contract in the constructor.
 	// They are used to verify the quorums in the received certificates.
 	// See getQuorumParametersAtLatestBlock for more details.
@@ -57,20 +65,36 @@ func NewCertVerifier(cfg *Config, log logging.Logger) (*CertVerifier, error) {
 		return nil, fmt.Errorf("failed to dial ETH RPC node: %s", err.Error())
 	}
 
-	// construct caller binding
-	m, err := edsm_binding.NewContractEigenDAServiceManagerCaller(common.HexToAddress(cfg.SvcManagerAddr), client)
+	// construct caller bindings
+	svcManagerCaller, err := edsm_binding.NewContractEigenDAServiceManagerCaller(common.HexToAddress(cfg.SvcManagerAddr), client)
 	if err != nil {
 		return nil, err
 	}
 
-	quorumsRequired, quorumAdversaryThresholds, err := getQuorumParametersAtLatestBlock(m)
+	// If the user has specified a custom cert verifier, use it.
+	var securityParamReader SecurityParamReader = svcManagerCaller
+	if cfg.CertVerifierV1Addr != "" {
+		log.Infof("Using custom EigenDACertVerifierV1 contract for cert verification at address: %s", cfg.CertVerifierV1Addr)
+		certVerifierCallerV1, err := v1_verifier_binding.NewContractEigenDACertVerifierV1Caller(
+			common.HexToAddress(cfg.CertVerifierV1Addr), client,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create EigenDACertVerifierV1 caller: %w", err)
+		}
+
+		securityParamReader = certVerifierCallerV1
+
+	}
+
+	quorumsRequired, quorumAdversaryThresholds, err := getQuorumParametersAtLatestBlock(securityParamReader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch quorum parameters from EigenDAServiceManager: %w", err)
 	}
 
 	return &CertVerifier{
 		log:                       log,
-		manager:                   m,
+		svcManagerCaller:          svcManagerCaller,
+		securityParamReader:       securityParamReader,
 		ethConfirmationDepth:      cfg.EthConfirmationDepth,
 		ethClient:                 client,
 		quorumsRequired:           quorumsRequired,
@@ -198,7 +222,7 @@ func (cv *CertVerifier) retrieveBatchMetadataHash(
 	batchID uint32,
 	blockNumber *big.Int,
 ) ([32]byte, error) {
-	onchainHash, err := cv.manager.BatchIdToBatchMetadataHash(
+	onchainHash, err := cv.svcManagerCaller.BatchIdToBatchMetadataHash(
 		&bind.CallOpts{Context: ctx, BlockNumber: blockNumber},
 		batchID,
 	)
@@ -228,17 +252,17 @@ func (cv *CertVerifier) retrieveBatchMetadataHash(
 // in the past,
 // which was not ideal. So we decided to make these parameters immutable, and cache them here.
 func getQuorumParametersAtLatestBlock(
-	manager *edsm_binding.ContractEigenDAServiceManagerCaller,
+	reader SecurityParamReader,
 ) ([]uint8, map[uint8]uint8, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	requiredQuorums, err := manager.QuorumNumbersRequired(&bind.CallOpts{Context: ctx})
+	requiredQuorums, err := reader.QuorumNumbersRequired(&bind.CallOpts{Context: ctx})
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to fetch QuorumNumbersRequired from EigenDAServiceManager: %w", err)
 	}
 	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	thresholds, err := manager.QuorumAdversaryThresholdPercentages(&bind.CallOpts{Context: ctx})
+	thresholds, err := reader.QuorumAdversaryThresholdPercentages(&bind.CallOpts{Context: ctx})
 	if err != nil {
 		return nil, nil, fmt.Errorf(
 			"failed to fetch QuorumAdversaryThresholdPercentages from EigenDAServiceManager: %w",

--- a/store/generated_key/eigenda/verify/cert.go
+++ b/store/generated_key/eigenda/verify/cert.go
@@ -44,7 +44,7 @@ type CertVerifier struct {
 
 	securityParamReader SecurityParamReader
 	ethClient           *ethclient.Client
-	// The two fields below are fetched from the EigenDAServiceManager contract in the constructor.
+	// The two fields below are fetched from the EigenDAServiceManager contract or the EigenDACertVerifierV1 (if configured) in the constructor.
 	// They are used to verify the quorums in the received certificates.
 	// See getQuorumParametersAtLatestBlock for more details.
 	quorumsRequired           []uint8

--- a/store/generated_key/eigenda/verify/cert.go
+++ b/store/generated_key/eigenda/verify/cert.go
@@ -44,7 +44,8 @@ type CertVerifier struct {
 
 	securityParamReader SecurityParamReader
 	ethClient           *ethclient.Client
-	// The two fields below are fetched from the EigenDAServiceManager contract or the EigenDACertVerifierV1 (if configured) in the constructor.
+	// The two fields below are fetched from the EigenDAServiceManager contract or
+	// the EigenDACertVerifierV1 (if configured) in the constructor.
 	// They are used to verify the quorums in the received certificates.
 	// See getQuorumParametersAtLatestBlock for more details.
 	quorumsRequired           []uint8
@@ -66,7 +67,8 @@ func NewCertVerifier(cfg *Config, log logging.Logger) (*CertVerifier, error) {
 	}
 
 	// construct caller bindings
-	svcManagerCaller, err := edsm_binding.NewContractEigenDAServiceManagerCaller(common.HexToAddress(cfg.SvcManagerAddr), client)
+	svcManagerCaller, err := edsm_binding.NewContractEigenDAServiceManagerCaller(
+		common.HexToAddress(cfg.SvcManagerAddr), client)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +85,6 @@ func NewCertVerifier(cfg *Config, log logging.Logger) (*CertVerifier, error) {
 		}
 
 		securityParamReader = certVerifierCallerV1
-
 	}
 
 	quorumsRequired, quorumAdversaryThresholds, err := getQuorumParametersAtLatestBlock(securityParamReader)

--- a/store/generated_key/eigenda/verify/cert.go
+++ b/store/generated_key/eigenda/verify/cert.go
@@ -23,6 +23,8 @@ import (
 	"golang.org/x/exp/slices"
 )
 
+// SecurityParamReader is an interface used reading quorums and thresholds from either
+// the EigenDAServiceManager or EigenDACertVerifierV1 contracts
 type SecurityParamReader interface {
 	QuorumAdversaryThresholdPercentages(opts *bind.CallOpts) ([]byte, error)
 	QuorumNumbersRequired(opts *bind.CallOpts) ([]uint8, error)

--- a/store/generated_key/eigenda/verify/cli.go
+++ b/store/generated_key/eigenda/verify/cli.go
@@ -47,8 +47,9 @@ func VerifierCLIFlags(envPrefix, category string) []cli.Flag {
 		},
 		&cli.StringFlag{
 			Name: EigenDACertVerifierV1FlagName,
-			Usage: `Address of EigenDACertVerifierV1 contract. Only necessary if using custom quorums/thresholds for certificate verification.
-						If no address is provided then the default EigenDAServiceManager parameters will be uesd.`,
+			Usage: `Address of EigenDACertVerifierV1 contract. Only necessary if using custom quorums/thresholds 
+					for certificate verification. If no address is provided then the default 
+					EigenDAServiceManager parameters will be uesd.`,
 			EnvVars:  []string{withEnvPrefix(envPrefix, "CERT_VERIFIER_V1")},
 			Category: category,
 		},

--- a/store/generated_key/eigenda/verify/cli.go
+++ b/store/generated_key/eigenda/verify/cli.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	EigenDACertVerifierV1FlagName = "cert-verifier-v1"
+	EigenDACertVerifierV1FlagName = withFlagPrefix("cert-verifier-v1")
 
 	// cert verification flags
 	CertVerificationDisabledFlagName = withFlagPrefix("cert-verification-disabled")
@@ -46,8 +46,9 @@ func VerifierCLIFlags(envPrefix, category string) []cli.Flag {
 			Category: category,
 		},
 		&cli.StringFlag{
-			Name:     EigenDACertVerifierV1FlagName,
-			Usage:    "Address of EigenDACertVerifierV1 contract. Only necessary if using custom quorums/thresholds for certificate verification. ",
+			Name: EigenDACertVerifierV1FlagName,
+			Usage: `Address of EigenDACertVerifierV1 contract. Only necessary if using custom quorums/thresholds for certificate verification.
+						If no address is provided then the default EigenDAServiceManager parameters will be uesd.`,
 			EnvVars:  []string{withEnvPrefix(envPrefix, "CERT_VERIFIER_V1")},
 			Category: category,
 		},

--- a/store/generated_key/eigenda/verify/cli.go
+++ b/store/generated_key/eigenda/verify/cli.go
@@ -11,6 +11,8 @@ import (
 )
 
 var (
+	EigenDACertVerifierV1FlagName = "cert-verifier-v1"
+
 	// cert verification flags
 	CertVerificationDisabledFlagName = withFlagPrefix("cert-verification-disabled")
 
@@ -41,6 +43,12 @@ func VerifierCLIFlags(envPrefix, category string) []cli.Flag {
 			Usage:    "Whether to verify certificates received from EigenDA disperser.",
 			EnvVars:  []string{withEnvPrefix(envPrefix, "CERT_VERIFICATION_DISABLED")},
 			Value:    false,
+			Category: category,
+		},
+		&cli.StringFlag{
+			Name:     EigenDACertVerifierV1FlagName,
+			Usage:    "Address of EigenDACertVerifierV1 contract. Only necessary if using custom quorums/thresholds for certificate verification. ",
+			EnvVars:  []string{withEnvPrefix(envPrefix, "CERT_VERIFIER_V1")},
 			Category: category,
 		},
 	}
@@ -119,6 +127,7 @@ func ReadConfig(ctx *cli.Context, clientConfigV1 common.ClientConfigV1) Config {
 		// reuse some configs from the eigenda client
 		RPCURL:               clientConfigV1.EdaClientCfg.EthRpcUrl,
 		SvcManagerAddr:       clientConfigV1.EdaClientCfg.SvcManagerAddr,
+		CertVerifierV1Addr:   ctx.String(EigenDACertVerifierV1FlagName),
 		EthConfirmationDepth: clientConfigV1.EdaClientCfg.WaitForConfirmationDepth,
 		WaitForFinalization:  clientConfigV1.EdaClientCfg.WaitForFinalization,
 	}

--- a/store/generated_key/eigenda/verify/verifier.go
+++ b/store/generated_key/eigenda/verify/verifier.go
@@ -30,6 +30,7 @@ type Config struct {
 	// below fields are only required if VerifyCerts is true
 	RPCURL               string
 	SvcManagerAddr       string
+	CertVerifierV1Addr   string // used if enabling custom quorums/thresholds
 	EthConfirmationDepth uint64
 	WaitForFinalization  bool
 	MaxBlobSizeBytes     uint64


### PR DESCRIPTION


## Fixes Issue
- Adds support for cert verification with custom quorums and thresholds by allowing an optional `EigenDACertVerfiierV1` address to be provided for which the required quorums and thresholds are read from 


<!-- Example: Closes #NNN -->
Fixes #

## Changes proposed

<!-- List all the proposed changes in your PR -->
<!-- Add the screenshots of the changes below if applicable -->

### Screenshots (Optional)

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
