### PR TITLE
chore: prettier config dump for eigenda backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ docker-build:
 	@docker build -t ghcr.io/layr-labs/eigenda-proxy:dev .
 
 run-memstore-server: build
-	./bin/eigenda-proxy --memstore.enabled --metrics.enabled
+	./bin/eigenda-proxy --memstore.enabled --metrics.enabled  --storage.backends-to-enable v2
 
 disperse-test-blob:
 	curl -X POST -d my-blob-content http://127.0.0.1:3100/put/ | xxd -p | tr -d '\n'

--- a/common/common.go
+++ b/common/common.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -82,6 +83,13 @@ const (
 	V1EigenDABackend EigenDABackend = iota + 1
 	V2EigenDABackend
 )
+
+// Used when marshalling the proxy config and logging to stdout at proxy startup.
+// []uint8 gets marshalled as a base64 string by default, which is unreadable.
+// This makes it so that it'll be marshalled as an array of strings instead.
+func (e EigenDABackend) MarshalJSON() ([]byte, error) {
+	return json.Marshal(EigenDABackendToString(e))
+}
 
 type InvalidBackendError struct {
 	Backend string


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #NNN` to link your PR with the
issue, replacing `#NNN` with the issue number you are fixing -->

Used when pretty printing the config dump on startup.
otherwise the []uint8 array was being marshalled to base64 which is unreadable.

Example new startup config dump:
![image](https://github.com/user-attachments/assets/00267aa8-4c70-48f9-a3db-d3c57d86ccaa)

Compare to the current config dump:
![image](https://github.com/user-attachments/assets/e3f90392-030d-4185-bdaa-6efc7d72aacf)

