### PR TITLE
chore: Clean up tests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,4 @@
     "references": true,
     "runtest": true
   },
-  "go.testEnvVars": {
-    "GO_ENV": "test"
-  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,13 @@
 {
-  "go.testEnvVars": {
-    "BACKEND": "memstore",
-    // To test against TESTNET, set SIGNER_PRIVATE_KEY and ETHEREUM_RPC.
-    "SIGNER_PRIVATE_KEY": "",
-    "ETHEREUM_RPC": "https://ethereum-holesky-rpc.publicnode.com"
+  "go.testEnvFile": "${workspaceFolder}/.env",
+  "go.testFlags": ["-v", "-test.parallel", "4", "-timeout", "5m"],
+  "go.loadEnvFile": true,
+  "go.useCodeLens": true,
+  "go.enableCodeLens": {
+    "references": true,
+    "runtest": true
   },
-  "go.testFlags": [
-    "-test.parallel",
-    "4",
-  ]
+  "go.testEnvVars": {
+    "GO_ENV": "test"
+  }
 }

--- a/test/testutils/setup.go
+++ b/test/testutils/setup.go
@@ -306,7 +306,7 @@ func BuildTestSuiteConfig(testCfg TestConfig) config.AppConfig {
 			PutTries:         3,
 		},
 		VerifierConfigV1: verify.Config{
-			VerifyCerts:          false,
+			VerifyCerts:          true,
 			RPCURL:               ethRPC,
 			SvcManagerAddr:       svcManagerAddress,
 			EthConfirmationDepth: 1,
@@ -321,6 +321,7 @@ func BuildTestSuiteConfig(testCfg TestConfig) config.AppConfig {
 			SRSOrder:        eigendaflags.SrsOrder,
 			SRSNumberToLoad: maxBlobLengthBytes / 32,
 			NumWorker:       uint64(runtime.GOMAXPROCS(0)), // #nosec G115
+			LoadG2Points:    true,
 		},
 		MemstoreConfig: memconfig.NewSafeConfig(
 			memconfig.Config{
@@ -357,6 +358,8 @@ func BuildTestSuiteConfig(testCfg TestConfig) config.AppConfig {
 		builderConfig.ClientConfigV1.EdaClientCfg.SignerPrivateKeyHex =
 			"0000000000000000000100000000000000000000000000000000000000000000"
 		builderConfig.ClientConfigV1.EdaClientCfg.SvcManagerAddr = "0x00000000069"
+		builderConfig.KzgConfig.LoadG2Points = false
+		builderConfig.VerifierConfigV1.VerifyCerts = false
 	}
 	switch {
 	case testCfg.UseKeccak256ModeS3:


### PR DESCRIPTION
- Enable V1 cert verification in e2e tests
- Remove duplicate server test
    - `testProxyClient` and `testProxyClientWriteRead` were functionally the same
- Reorganize server tests
    - put "basic test" at the top
    - put utility functions at the bottom
- Make some tweaks to `settings.json`
    - I don't think it's a good idea to have a private key field in a committed file: you're just asking to leak the key like that. New `settings.json` relies on a `.env` to hold required vars for tests
    - I added a 5m test timeout, to override the default 30s