### PR TITLE
feat: configure memstore return instructed status code

### DIFF
--- a/clients/memconfig_client/client.go
+++ b/clients/memconfig_client/client.go
@@ -20,10 +20,7 @@ type Config struct {
 }
 
 type InstructedMode struct {
-	// error injection
-	// TODO this should have been an error type, currently we have recency error -1
-	// coretypes.VerificationStatusCode taking 0..5 (inclusive), where only 1 is deemed
-	// as normal
+	// return status code
 	GetReturnsStatusCode int
 	// if activated, GetReturnsStatusCode can be set to 1 to ensure normal operation
 	IsActivated bool

--- a/store/generated_key/memstore/README.md
+++ b/store/generated_key/memstore/README.md
@@ -48,6 +48,25 @@ $ curl http://localhost:3100/memstore/config | \
   curl -X PATCH http://localhost:3100/memstore/config -d @-
 ```
 
+### Instructed Mode
+
+The instructed mode allows users to set a desired returned status code for some payloads the user is about to write. The next time when a user requests to get the payloads with keys, the proxy returns the error according to the status code set earlier. The status code is sticky, and
+can affect all subsequent writes. By default, the memstore isinitialized without the instructive mode.
+
+```bash
+ curl -X PATCH http://localhost:3100/memstore/config -d '{"InstructedMode": {"GetReturnsStatusCode": 3, "IsActivated": true }}'
+ {"MaxBlobSizeBytes":2048,"BlobExpiration":"45m0s","PutLatency":"0s","GetLatency":"0s","PutReturnsFailoverError":false,"InstructedMode":{"GetReturnsStatusCode":3,"IsActivated":true}}
+```
+
+A user can only activate the instructed mode via http PATCH method above. A user can switch to other status code by sending a new `PATCH`
+request, the GET for subsequent writes contains the new status code. There are currently seven available status codes
+```
+-1: Recency error. The proxy returns 418 with json string containing status code -1
+1: Success. The proxy returns 200 with user payload, as if it is not using the instructed mode
+0,2,3,4,5: Invalid Cert. The proxy returns 418 with json string containing the corresponding status code
+```
+
+A very important invariant which the instructed mode hold is that no key can ever be overwritten. This is important for all rollup use cases.
 
 ### Golang client
 A simple HTTP client implementation lives in `/clients/memconfig_client/` and can be imported for manipulating the config using more structured types.

--- a/store/generated_key/memstore/cli.go
+++ b/store/generated_key/memstore/cli.go
@@ -16,6 +16,7 @@ var (
 	PutLatencyFlagName              = withFlagPrefix("put-latency")
 	GetLatencyFlagName              = withFlagPrefix("get-latency")
 	PutReturnsFailoverErrorFlagName = withFlagPrefix("put-returns-failover-error")
+	GetReturnsStatusCodeFlagName    = withFlagPrefix("get-returnsstatus-code-error")
 )
 
 func withFlagPrefix(s string) string {
@@ -102,6 +103,16 @@ func CLIFlags(envPrefix, category string) []cli.Flag {
 			EnvVars:  []string{withEnvPrefix(envPrefix, "PUT_RETURNS_FAILOVER_ERROR")},
 			Category: category,
 		},
+		&cli.IntFlag{
+			Name: GetReturnsStatusCodeFlagName,
+			Usage: fmt.Sprintf(
+				"When set to other than 1, Put requests will return a application status code error, after sleeping for --%s duration.",
+				PutLatencyFlagName,
+			),
+			Value:    1,
+			EnvVars:  []string{withEnvPrefix(envPrefix, "GET_RETURNS_STATUS_CODE_ERROR")},
+			Category: category,
+		},
 	}
 }
 
@@ -113,5 +124,6 @@ func ReadConfig(ctx *cli.Context, maxBlobSizeBytes uint64) (*memconfig.SafeConfi
 			PutLatency:              ctx.Duration(PutLatencyFlagName),
 			GetLatency:              ctx.Duration(GetLatencyFlagName),
 			PutReturnsFailoverError: ctx.Bool(PutReturnsFailoverErrorFlagName),
+			GetReturnsStatusCode:    ctx.Int(GetReturnsStatusCodeFlagName),
 		}), nil
 }

--- a/store/generated_key/memstore/cli.go
+++ b/store/generated_key/memstore/cli.go
@@ -16,7 +16,7 @@ var (
 	PutLatencyFlagName              = withFlagPrefix("put-latency")
 	GetLatencyFlagName              = withFlagPrefix("get-latency")
 	PutReturnsFailoverErrorFlagName = withFlagPrefix("put-returns-failover-error")
-	GetReturnsStatusCodeFlagName    = withFlagPrefix("get-returnsstatus-code-error")
+	GetReturnsStatusCodeFlagName    = withFlagPrefix("get-returns-status-code")
 )
 
 func withFlagPrefix(s string) string {
@@ -106,11 +106,11 @@ func CLIFlags(envPrefix, category string) []cli.Flag {
 		&cli.IntFlag{
 			Name: GetReturnsStatusCodeFlagName,
 			Usage: fmt.Sprintf(
-				"When set to other than 1, Put requests will return a application status code error, after sleeping for --%s duration.",
+				"When set to other than 1, Put requests will return an application status code error, after sleeping for --%s duration.",
 				PutLatencyFlagName,
 			),
 			Value:    1,
-			EnvVars:  []string{withEnvPrefix(envPrefix, "GET_RETURNS_STATUS_CODE_ERROR")},
+			EnvVars:  []string{withEnvPrefix(envPrefix, "GET_RETURNS_STATUS_CODE")},
 			Category: category,
 		},
 	}

--- a/store/generated_key/memstore/cli.go
+++ b/store/generated_key/memstore/cli.go
@@ -16,7 +16,6 @@ var (
 	PutLatencyFlagName              = withFlagPrefix("put-latency")
 	GetLatencyFlagName              = withFlagPrefix("get-latency")
 	PutReturnsFailoverErrorFlagName = withFlagPrefix("put-returns-failover-error")
-	GetReturnsStatusCodeFlagName    = withFlagPrefix("get-returns-status-code")
 )
 
 func withFlagPrefix(s string) string {
@@ -103,16 +102,6 @@ func CLIFlags(envPrefix, category string) []cli.Flag {
 			EnvVars:  []string{withEnvPrefix(envPrefix, "PUT_RETURNS_FAILOVER_ERROR")},
 			Category: category,
 		},
-		&cli.IntFlag{
-			Name: GetReturnsStatusCodeFlagName,
-			Usage: fmt.Sprintf(
-				"When set to other than 1, Put requests will return an application status code error, after sleeping for --%s duration.",
-				PutLatencyFlagName,
-			),
-			Value:    1,
-			EnvVars:  []string{withEnvPrefix(envPrefix, "GET_RETURNS_STATUS_CODE")},
-			Category: category,
-		},
 	}
 }
 
@@ -124,6 +113,5 @@ func ReadConfig(ctx *cli.Context, maxBlobSizeBytes uint64) (*memconfig.SafeConfi
 			PutLatency:              ctx.Duration(PutLatencyFlagName),
 			GetLatency:              ctx.Duration(GetLatencyFlagName),
 			PutReturnsFailoverError: ctx.Bool(PutReturnsFailoverErrorFlagName),
-			GetReturnsStatusCode:    ctx.Int(GetReturnsStatusCodeFlagName),
 		}), nil
 }

--- a/store/generated_key/memstore/ephemeraldb/ephemeral_db.go
+++ b/store/generated_key/memstore/ephemeraldb/ephemeral_db.go
@@ -97,7 +97,7 @@ func (db *DB) InsertEntry(key []byte, value []byte) error {
 		db.keyStarts[strKey] = time.Now()
 	}
 
-	// write always succeed even instructed to return error on Get
+	// write always succeed, the instructed status code show up on read path
 	return nil
 }
 

--- a/store/generated_key/memstore/ephemeraldb/ephemeral_db.go
+++ b/store/generated_key/memstore/ephemeraldb/ephemeral_db.go
@@ -75,7 +75,7 @@ func (db *DB) InsertEntry(key []byte, value []byte) error {
 	statusCode := db.config.GetReturnsStatusCode()
 	if statusCode != int(coretypes.StatusSuccess) {
 		db.log.Info("InsertEntry to memstore with special status code", "statusCode", statusCode)
-		// If instructed to return a non Success Status, the memstore stores the error message
+		// If instructed to return a non Success Status(1), the memstore stores the error message
 		// on return. TODO we should group all the error into a single error type
 		// StatusRequiredQuorumsNotSubset is the highest iota. -1 is recency error
 		if statusCode < -1 || statusCode > int(coretypes.StatusRequiredQuorumsNotSubset) {
@@ -86,6 +86,7 @@ func (db *DB) InsertEntry(key []byte, value []byte) error {
 		if exists {
 			return fmt.Errorf("memstore is configured to return instructed status code, payload key already exists in ephemeral db: %s", strKey)
 		}
+		// not BlobExpiration
 		db.instructedStatusCode[strKey] = statusCode
 	} else {
 		_, exists := db.store[strKey]
@@ -94,8 +95,8 @@ func (db *DB) InsertEntry(key []byte, value []byte) error {
 		}
 
 		db.store[strKey] = value
-		// add expiration if applicable
 
+		// add expiration if applicable
 		if db.config.BlobExpiration() > 0 {
 			db.keyStarts[strKey] = time.Now()
 		}

--- a/store/generated_key/memstore/ephemeraldb/ephemeral_db.go
+++ b/store/generated_key/memstore/ephemeraldb/ephemeral_db.go
@@ -112,7 +112,11 @@ func (db *DB) FetchEntry(key []byte) ([]byte, error) {
 	if instructedExists {
 		// should have been defended in the SET http router path
 		if statusCode < -1 || statusCode > int(coretypes.StatusRequiredQuorumsNotSubset) {
-			panic("memstore is configured to return an unknown status code in FetchEntry. Unable to serve the get")
+			panic("memstore is configured to return an unknown status code in FetchEntry")
+		}
+
+		if statusCode == int(coretypes.StatusSuccess) {
+			panic("memstore cannot return error for SuccessStatusCode in the instructed mode")
 		}
 
 		if statusCode == -1 {

--- a/store/generated_key/memstore/ephemeraldb/ephemeral_db.go
+++ b/store/generated_key/memstore/ephemeraldb/ephemeral_db.go
@@ -20,6 +20,13 @@ const (
 	DefaultPruneInterval = 500 * time.Millisecond
 )
 
+// a wrapper around payload with status code
+// if instructed mode is not enabled, the status code is 1
+type payloadWithStatus struct {
+	payload    []byte
+	statusCode int
+}
+
 // DB ... An ephemeral && simple in-memory database used to emulate
 // an EigenDA network for dispersal/retrieval operations.
 type DB struct {
@@ -28,20 +35,18 @@ type DB struct {
 	log    logging.Logger
 
 	// mu guards the below fields
-	mu                             sync.RWMutex
-	keyStarts                      map[string]time.Time // used for managing expiration
-	store                          map[string][]byte    // db
-	instructedNonSuccessStatusCode map[string]int       // a map storing keys with instructed status code
+	mu        sync.RWMutex
+	keyStarts map[string]time.Time         // used for managing expiration
+	store     map[string]payloadWithStatus // db
 }
 
 // New ... constructor
 func New(ctx context.Context, cfg *memconfig.SafeConfig, log logging.Logger) *DB {
 	db := &DB{
-		config:                         cfg,
-		keyStarts:                      make(map[string]time.Time),
-		store:                          make(map[string][]byte),
-		instructedNonSuccessStatusCode: make(map[string]int),
-		log:                            log,
+		config:    cfg,
+		keyStarts: make(map[string]time.Time),
+		store:     make(map[string]payloadWithStatus),
+		log:       log,
 	}
 
 	// if no expiration set then blobs will be persisted indefinitely
@@ -73,29 +78,23 @@ func (db *DB) InsertEntry(key []byte, value []byte) error {
 	strKey := string(key)
 
 	activated, statusCode := db.config.GetInstructedMode()
-	// if isActivatedNormalOps, the data is stored in
-	isActivatedNormalOps := activated && statusCode == int(coretypes.StatusSuccess)
 
-	if !activated || isActivatedNormalOps {
-		_, exists := db.store[strKey]
-		if exists {
-			return fmt.Errorf("payload key already exists in ephemeral db: %s", strKey)
-		}
+	// disallow any overwrite
+	_, exists := db.store[strKey]
+	if exists {
+		return fmt.Errorf("payload key already exists in ephemeral db: %s", strKey)
+	}
 
-		db.store[strKey] = value
+	// force status code for all valid inputs
+	if !activated {
+		statusCode = 1
+	}
 
-		// add expiration if applicable
-		if db.config.BlobExpiration() > 0 {
-			db.keyStarts[strKey] = time.Now()
-		}
-	} else {
-		db.log.Info("InsertEntry to memstore with special status code", "statusCode", statusCode)
-		_, exists := db.instructedNonSuccessStatusCode[strKey]
-		if exists {
-			return fmt.Errorf("memstore returns instructed status code, but key already exists: %s", strKey)
-		}
-		// not BlobExpiration
-		db.instructedNonSuccessStatusCode[strKey] = statusCode
+	db.store[strKey] = payloadWithStatus{payload: value, statusCode: statusCode}
+
+	// add expiration if applicable
+	if db.config.BlobExpiration() > 0 {
+		db.keyStarts[strKey] = time.Now()
 	}
 
 	// write always succeed even instructed to return error on Get
@@ -108,19 +107,20 @@ func (db *DB) FetchEntry(key []byte) ([]byte, error) {
 	db.mu.RLock()
 	defer db.mu.RUnlock()
 
-	statusCode, instructedExists := db.instructedNonSuccessStatusCode[string(key)]
-	if instructedExists {
+	payloadWithStatus, exists := db.store[string(key)]
+	if !exists {
+		return nil, fmt.Errorf("payload not found for key: %s", string(key))
+	}
+
+	statusCode := payloadWithStatus.statusCode
+	if statusCode != int(coretypes.StatusSuccess) {
 		// should have been defended in the SET http router path
 		if statusCode < -1 || statusCode > int(coretypes.StatusRequiredQuorumsNotSubset) {
 			panic("memstore is configured to return an unknown status code in FetchEntry")
 		}
 
-		if statusCode == int(coretypes.StatusSuccess) {
-			panic("memstore cannot return error for SuccessStatusCode in the instructed mode")
-		}
-
 		if statusCode == -1 {
-			return nil, eigenda.RBNRecencyCheckFailedError{}
+			return nil, &eigenda.RBNRecencyCheckFailedError{}
 		}
 
 		// the error msg the retriever would receive on the get path
@@ -133,13 +133,7 @@ func (db *DB) FetchEntry(key []byte) ([]byte, error) {
 		return nil, &err
 	}
 
-	payload, exists := db.store[string(key)]
-
-	if !exists {
-		return nil, fmt.Errorf("payload not found for key: %s", string(key))
-	}
-
-	return payload, nil
+	return payloadWithStatus.payload, nil
 }
 
 // pruningLoop ... runs a background goroutine to prune expired blobs from the store on a regular interval.

--- a/store/generated_key/memstore/ephemeraldb/ephemeral_db_test.go
+++ b/store/generated_key/memstore/ephemeraldb/ephemeral_db_test.go
@@ -7,7 +7,10 @@ import (
 	"time"
 
 	"github.com/Layr-Labs/eigenda-proxy/store/generated_key/memstore/memconfig"
+	eigenda "github.com/Layr-Labs/eigenda-proxy/store/generated_key/v2"
 	"github.com/Layr-Labs/eigenda/api"
+	"github.com/Layr-Labs/eigenda/api/clients/v2/coretypes"
+	"github.com/Layr-Labs/eigenda/api/clients/v2/verification"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/stretchr/testify/require"
 )
@@ -119,4 +122,61 @@ func TestPutReturnsFailoverErrorConfig(t *testing.T) {
 
 	err = db.InsertEntry(testKey, []byte("some-value"))
 	require.ErrorIs(t, err, &api.ErrorFailover{})
+}
+
+func TestInstructedModeConfig(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	config := testConfig()
+	db := New(ctx, config, testLogger)
+	testKey := []byte("som-key")
+
+	// status code 3 corresponds to coretypes.VerificationStatusCode
+	err := config.SetInstructedMode(memconfig.InstructedMode{IsActivated: true, GetReturnsStatusCode: 3})
+	require.NoError(t, err)
+
+	// write is not affected
+	err = db.InsertEntry(testKey, []byte("some-value"))
+	require.NoError(t, err)
+
+	// read returns an error
+	var expectedError *verification.CertVerificationFailedError
+	_, err = db.FetchEntry(testKey)
+	require.ErrorAs(t, err, &expectedError)
+
+	require.Equal(t, expectedError.StatusCode, coretypes.StatusSecurityAssumptionsNotMet)
+
+	// status code -1 corresponds to recency error
+	err = config.SetInstructedMode(memconfig.InstructedMode{IsActivated: true, GetReturnsStatusCode: -1})
+	require.NoError(t, err)
+
+	// cannot overwrite any value even in instructed mode
+	err = db.InsertEntry(testKey, []byte("another-value"))
+	require.ErrorContains(t, err, "key already exists")
+
+	anotherTestKey := []byte("som-other-key")
+	err = db.InsertEntry(anotherTestKey, []byte("another-value"))
+	require.NoError(t, err)
+
+	// read returns an error
+	var recencyError *eigenda.RBNRecencyCheckFailedError
+	_, err = db.FetchEntry(anotherTestKey)
+	require.ErrorAs(t, err, &recencyError)
+
+	// now deactivate Instruction mode
+	err = config.SetInstructedMode(memconfig.InstructedMode{IsActivated: false, GetReturnsStatusCode: 3})
+	require.NoError(t, err)
+
+	yetTestKey := []byte("yet-another-som-key")
+	err = db.InsertEntry(yetTestKey, []byte("another-value"))
+	require.NoError(t, err)
+	_, err = db.FetchEntry(yetTestKey)
+	require.NoError(t, err)
+
+	// but still you cannot overwrite anything
+	err = db.InsertEntry(anotherTestKey, []byte("another-value"))
+	require.ErrorContains(t, err, "key already exists")
 }

--- a/store/generated_key/memstore/memconfig/config.go
+++ b/store/generated_key/memstore/memconfig/config.go
@@ -17,6 +17,11 @@ type Config struct {
 	// after sleeping PutLatency duration.
 	// This can be used to simulate eigenda being down.
 	PutReturnsFailoverError bool
+	// error injection
+	// TODO this should have been an error type, currently we have recency error -1
+	// coretypes.VerificationStatusCode taking 0..5 inclusive, where only 1 is deemed
+	// as normal
+	GetReturnsStatusCode int
 }
 
 // MarshalJSON implements custom JSON marshaling for Config.
@@ -32,12 +37,14 @@ func (c Config) MarshalJSON() ([]byte, error) {
 		PutLatency              string
 		GetLatency              string
 		PutReturnsFailoverError bool
+		GetReturnsStatusCode    int
 	}{
 		MaxBlobSizeBytes:        c.MaxBlobSizeBytes,
 		BlobExpiration:          c.BlobExpiration.String(),
 		PutLatency:              c.PutLatency.String(),
 		GetLatency:              c.GetLatency.String(),
 		PutReturnsFailoverError: c.PutReturnsFailoverError,
+		GetReturnsStatusCode:    c.GetReturnsStatusCode,
 	})
 }
 
@@ -116,6 +123,17 @@ func (sc *SafeConfig) SetMaxBlobSizeBytes(maxBlobSizeBytes uint64) {
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
 	sc.config.MaxBlobSizeBytes = maxBlobSizeBytes
+}
+
+func (sc *SafeConfig) GetReturnsStatusCode() int {
+	sc.mu.RLock()
+	defer sc.mu.RUnlock()
+	return sc.config.GetReturnsStatusCode
+}
+func (sc *SafeConfig) SetGETReturnsStatusCode(statusCode int) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	sc.config.GetReturnsStatusCode = statusCode
 }
 
 func (sc *SafeConfig) Config() Config {

--- a/store/generated_key/memstore/memconfig/config.go
+++ b/store/generated_key/memstore/memconfig/config.go
@@ -10,10 +10,7 @@ import (
 )
 
 type InstructedMode struct {
-	// error injection
-	// TODO this should have been an error type, currently we have recency error -1
-	// coretypes.VerificationStatusCode taking 0..5 (inclusive), where only 1 is deemed
-	// as normal
+	// return status code
 	GetReturnsStatusCode int `json:"GetReturnsStatusCode,omitempty"`
 	// if activated, GetReturnsStatusCode can be set to 1 to ensure normal operation
 	IsActivated bool `json:"IsActivated,omitempty"`

--- a/store/generated_key/memstore/memconfig/http_handlers.go
+++ b/store/generated_key/memstore/memconfig/http_handlers.go
@@ -17,6 +17,7 @@ type ConfigUpdate struct {
 	GetLatency              *string `json:"GetLatency,omitempty"`
 	PutReturnsFailoverError *bool   `json:"PutReturnsFailoverError,omitempty"`
 	BlobExpiration          *string `json:"BlobExpiration,omitempty"`
+	GetReturnsStatusCode    *int    `json:"GetReturnsStatusCode,omitempty"`
 }
 
 // HandlerHTTP is an admin HandlerHTTP for GETting and PATCHing the memstore configuration.
@@ -96,6 +97,10 @@ func (api HandlerHTTP) handleUpdateConfig(w http.ResponseWriter, r *http.Request
 			return
 		}
 		api.safeConfig.SetBlobExpiration(duration)
+	}
+
+	if update.GetReturnsStatusCode != nil {
+		api.safeConfig.SetGETReturnsStatusCode(*update.GetReturnsStatusCode)
 	}
 
 	// Return the current configuration

--- a/store/generated_key/memstore/memconfig/http_handlers_test.go
+++ b/store/generated_key/memstore/memconfig/http_handlers_test.go
@@ -137,6 +137,28 @@ func TestHandlersHTTP_PatchConfig(t *testing.T) {
 			},
 		},
 		{
+			name:            "update instructed mode",
+			initialConfig:   Config{},
+			requestBodyJSON: `{"InstructedMode": {"GetReturnsStatusCode": 3, "IsActivated": true }}`,
+			expectedStatus:  http.StatusOK,
+			validate: func(t *testing.T, inputConfig Config, sc *SafeConfig) {
+				outputConfig := sc.Config()
+				inputConfig.InstructedMode.IsActivated = true
+				inputConfig.InstructedMode.GetReturnsStatusCode = 3
+				require.Equal(t, inputConfig, outputConfig)
+			},
+		},
+		{
+			name:            "invalid update to instructed mode (status code 100 does not exist)",
+			initialConfig:   Config{},
+			requestBodyJSON: `{"InstructedMode": {"GetReturnsStatusCode": 100, "IsActivated": true }}`,
+			expectedStatus:  http.StatusBadRequest,
+			validate: func(t *testing.T, inputConfig Config, sc *SafeConfig) {
+				outputConfig := sc.Config()
+				require.Equal(t, inputConfig, outputConfig)
+			},
+		},
+		{
 			name: "update multiple fields",
 			initialConfig: Config{
 				MaxBlobSizeBytes:        1024,
@@ -162,7 +184,8 @@ func TestHandlersHTTP_PatchConfig(t *testing.T) {
 				"BlobExpiration": "1h",
 				"PutLatency": "1s",
 				"GetLatency": "2s",
-				"PutReturnsFailoverError": true
+				"PutReturnsFailoverError": true,
+				"InstructedMode": {"GetReturnsStatusCode": 3, "IsActivated": true }
 			}`,
 			expectedStatus: http.StatusOK,
 			validate: func(t *testing.T, inputConfig Config, sc *SafeConfig) {
@@ -172,6 +195,8 @@ func TestHandlersHTTP_PatchConfig(t *testing.T) {
 				inputConfig.PutLatency = 1 * time.Second
 				inputConfig.GetLatency = 2 * time.Second
 				inputConfig.PutReturnsFailoverError = true
+				inputConfig.InstructedMode.GetReturnsStatusCode = 3
+				inputConfig.InstructedMode.IsActivated = true
 				require.Equal(t, inputConfig, outputConfig)
 			},
 		},


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #NNN` to link your PR with the
issue, replacing `#NNN` with the issue number you are fixing -->

## Fixes Issue

Fixes #DAINT-574

## Changes proposed 

The instructed mode allows users to set a desired returned status code for some payloads the user is about to write. The next time when a user requests to get the payloads with keys, the proxy returns the error according to the status code set earlier. The status code is sticky, and
can affect all subsequent writes. By default, the memstore isinitialized without the instructive mode.

```bash
 curl -X PATCH http://localhost:3100/memstore/config -d '{"InstructedMode": {"GetReturnsStatusCode": 3, "IsActivated": true }}'
 {"MaxBlobSizeBytes":2048,"BlobExpiration":"45m0s","PutLatency":"0s","GetLatency":"0s","PutReturnsFailoverError":false,"InstructedMode":{"GetReturnsStatusCode":3,"IsActivated":true}}
```

A user can only activate the instructed mode via http PATCH method above. A user can switch to other status code by sending a new `PATCH`
request, the retrieveal for subsequent writes would contain the new status code. There are currently seven available status codes
```
-1: Recency error. The proxy returns 418 with json string containing status code -1
1: Success. The proxy returns 200 with user payload, as if it is not using the instructed mode
0,2,3,4,5: Invalid Cert. The proxy returns 418 with json string containing the corresponding status code
```

A very important invariant which the instructed mode hold is that no key can ever be overwritten. This is important for all rollup use cases.

## Note to reviewers

Where it is used
- https://github.com/Layr-Labs/optimism/blob/869c01633cb80d0afd3727dadd0b8a2b2e8e687b/op-e2e/actions/proofs/helpers/eigenda_proxy.go#L23
- https://github.com/Layr-Labs/optimism/blob/869c01633cb80d0afd3727dadd0b8a2b2e8e687b/op-e2e/actions/proofs/eigenda_drop_cert_test.go#L113-L127

Built on top of #406, need to plan for merge