### PR TITLE
fix: network id check bug (can't start on preprod)

### DIFF
--- a/common/client_config_v2.go
+++ b/common/client_config_v2.go
@@ -48,7 +48,7 @@ type ClientConfigV2 struct {
 	RBNRecencyWindowSize uint64
 
 	// The EigenDA network that is being used.
-	// It is optional, and when set will be used for validating that the eth-rpc chain ID matches network.
+	// It is optional, and when set will be used for validating that the eth-rpc chain ID matches the network.
 	EigenDANetwork EigenDANetwork
 }
 

--- a/common/client_config_v2.go
+++ b/common/client_config_v2.go
@@ -47,7 +47,8 @@ type ClientConfigV2 struct {
 	// This check is optional and will be skipped when RBNRecencyWindowSize is set to 0.
 	RBNRecencyWindowSize uint64
 
-	// The EigenDA network that is being used. Used for validating chain ID matches network.
+	// The EigenDA network that is being used.
+	// It is optional, and when set will be used for validating that the eth-rpc chain ID matches network.
 	EigenDANetwork EigenDANetwork
 }
 

--- a/common/eigenda_network.go
+++ b/common/eigenda_network.go
@@ -57,18 +57,18 @@ func (n EigenDANetwork) String() string {
 }
 
 // chainIDToNetworkMap maps chain IDs to EigenDA networks
-var chainIDToNetworkMap = map[string]EigenDANetwork{
-	"17000":    HoleskyTestnetEigenDANetwork,
-	"11155111": SepoliaTestnetEigenDANetwork,
+var chainIDToNetworkMap = map[string][]EigenDANetwork{
+	"17000":    {HoleskyTestnetEigenDANetwork, HoleskyPreprodEigenDANetwork},
+	"11155111": {SepoliaTestnetEigenDANetwork},
 }
 
-// EigenDANetworkFromChainID returns the EigenDA network for a given chain ID
-func EigenDANetworkFromChainID(chainID string) (EigenDANetwork, error) {
-	network, ok := chainIDToNetworkMap[chainID]
+// EigenDANetworksFromChainID returns the EigenDA network(s) for a given chain ID
+func EigenDANetworksFromChainID(chainID string) ([]EigenDANetwork, error) {
+	networks, ok := chainIDToNetworkMap[chainID]
 	if !ok {
-		return "", fmt.Errorf("unknown chain ID: %s", chainID)
+		return nil, fmt.Errorf("unknown chain ID: %s", chainID)
 	}
-	return network, nil
+	return networks, nil
 }
 
 func EigenDANetworkFromString(inputString string) (EigenDANetwork, error) {

--- a/store/builder/storage_manager_builder.go
+++ b/store/builder/storage_manager_builder.go
@@ -406,21 +406,21 @@ func buildEthClient(ctx context.Context, log logging.Logger, secretConfigV2 comm
 		return nil, fmt.Errorf("failed to get chain ID from ETH RPC: %w", err)
 	}
 
-	log.Info("Using chain id: %d", chainID.Uint64())
+	log.Infof("Using chain id: %d", chainID.Uint64())
 
 	// Validate that the chain ID matches the expected network
 	if expectedNetwork != "" {
-		actualNetwork, err := common.EigenDANetworkFromChainID(chainID.String())
+		actualNetworks, err := common.EigenDANetworksFromChainID(chainID.String())
 		if err != nil {
 			return nil, fmt.Errorf("unknown chain ID %s: %w", chainID.String(), err)
 		}
-		if actualNetwork != expectedNetwork {
-			return nil, fmt.Errorf("network mismatch: expected %s (based on configuration), but ETH RPC"+
+		if !slices.Contains(actualNetworks, expectedNetwork) {
+			return nil, fmt.Errorf("network mismatch: expected %s (based on configuration), but ETH RPC "+
 				"returned chain ID %s which corresponds to %s",
-				expectedNetwork, chainID.String(), actualNetwork)
+				expectedNetwork, chainID.String(), actualNetworks)
 		}
 
-		log.Info("Detected EigenDA network: %s. Will use for reading network default values if overrides"+
+		log.Infof("Detected EigenDA network: %s. Will use for reading network default values if overrides "+
 			"aren't provided.", expectedNetwork.String())
 	}
 


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #NNN` to link your PR with the
issue, replacing `#NNN` with the issue number you are fixing -->

## Fixes Issue

The behavior of proxy sould work fine for any external customers. But the way the chainid check is currently implemented makes it impossible to start proxy on our preprod environment. This PR fixes that.

> It had testnet hardcoded on chainid 17000, so wasn't possible to start proxy on preprod (which is also on 17000).
> Changed to alow multiple eigneda networks per chainid

<!-- Example: Closes #NNN -->
Fixes #

## Changes proposed

<!-- List all the proposed changes in your PR -->
<!-- Add the screenshots of the changes below if applicable -->

### Screenshots (Optional)

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
